### PR TITLE
Change charms to use juju-http{s}-proxy model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ principal charm.
 See [config.yaml](config.yaml) for
 list of configuration options.
 
-> Note: Setting HTTP proxy values will be override `juju-http-proxy` or `juju-https-proxy` on the model
+> Note: Setting HTTP proxy values will override `juju-http-proxy` or `juju-https-proxy` on the model
 
 # Contact Information
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ principal charm.
 See [config.yaml](config.yaml) for
 list of configuration options.
 
-> Note: Setting HTTP proxy values will be overriden if `juju-http-proxy` or `juju-https-proxy` settings are set on the model.
-
-# Testing
-
-When upgrading this charm, the [`container_runtime_version`](https://github.com/VariableDeclared/jenkins/blob/3bf2cabc7185568e6a80a137a7f083c428048683/jobs/validate-juju-https-envs.yaml#L25) of the `validate-https-proxy-envs` key needs to be updated with the new containerd version.
+> Note: Setting HTTP proxy values will be override `juju-http-proxy` or `juju-https-proxy` on the model
 
 # Contact Information
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ list of configuration options.
 
 > Note: Setting HTTP proxy values will be overriden if `juju-http-proxy` or `juju-https-proxy` settings are set on the model.
 
+# Testing
+
+When upgrading this charm, the [`container_runtime_version`](https://github.com/VariableDeclared/jenkins/blob/3bf2cabc7185568e6a80a137a7f083c428048683/jobs/validate-juju-https-envs.yaml#L25) of the `validate-https-proxy-envs` key needs to be updated with the new containerd version.
+
 # Contact Information
 
 This charm is available at <https://jujucharms.com/containerd> and contains the

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ engine within a running Juju charm application. Containerd is an open platform
 for developers and sysadmins to build, ship, and run distributed applications
 in containers.
 
-Containerd focuses on distributing applications as containers that can be quickly 
-assembled from components that are run the same on different servers without 
-environmental dependencies. This eliminates the friction between development, 
+Containerd focuses on distributing applications as containers that can be quickly
+assembled from components that are run the same on different servers without
+environmental dependencies. This eliminates the friction between development,
 QA, and production environments.
 
 # States
@@ -23,7 +23,7 @@ The following states are set by this subordinate:
 
 The Containerd subordinate charm is to be used with principal
 charms that need a container runtime.  To use, we deploy
-the Containerd subordinate charm and then relate it to the 
+the Containerd subordinate charm and then relate it to the
 principal charm.
 
 ```
@@ -41,14 +41,14 @@ principal charm.
 See [config.yaml](config.yaml) for
 list of configuration options.
 
+> Note: Setting HTTP proxy values will be overriden if `juju-http-proxy` or `juju-https-proxy` settings are set on the model.
 
 # Contact Information
 
-This charm is available at <https://jujucharms.com/containerd> and contains the 
-open source operations code to deploy on all public clouds in the Juju 
+This charm is available at <https://jujucharms.com/containerd> and contains the
+open source operations code to deploy on all public clouds in the Juju
 ecosystem.
 
 ## Containerd links
 
   - The [Containerd homepage](https://containerd.io/)
-

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -311,10 +311,7 @@ def proxy_changed():
     """
     # Create "dumb" context based on Config
     # to avoid triggering config.changed.
-    context = dict(config())
-
-    modified_config = check_for_juju_https_proxy(config)
-    context.update(modified_config)
+    context = check_for_juju_https_proxy(config)
 
     service_file = 'proxy.conf'
     service_directory = '/etc/systemd/system/containerd.service.d'

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -22,7 +22,8 @@ from charms.reactive import (
 from charms.layer.container_runtime_common import (
     ca_crt_path,
     server_crt_path,
-    server_key_path
+    server_key_path,
+    check_for_juju_https_proxy
 )
 
 from charmhelpers.core import host
@@ -45,7 +46,6 @@ from charmhelpers.fetch import (
     apt_autoremove,
     import_key
 )
-
 
 DB = unitdata.kv()
 
@@ -268,13 +268,8 @@ def config_changed():
     # to avoid triggering config.changed.
     context = dict(config())
 
-    # If juju environment variables are defined, take precedent
-    # over config.yaml.
-    # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
-    environment_config = env_proxy_settings()
-    if environment_config is not None:
-        config().update(environment_config)
-
+    modified_config = check_for_juju_https_proxy(config)
+    context.update(modified_config)
 
     config_file = 'config.toml'
     config_directory = '/etc/containerd'

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -273,7 +273,7 @@ def config_changed():
     # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
     environment_config = env_proxy_settings()
     if environment_config is not None:
-        config.update(environment_config)
+        config().update(environment_config)
 
 
     config_file = 'config.toml'

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -3,11 +3,20 @@ import json
 import requests
 import traceback
 
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import (
+    check_call,
+    check_output,
+    CalledProcessError
+)
 
 from charms.reactive import endpoint_from_flag
 from charms.reactive import (
-    when, when_not, when_any, set_state, is_state, remove_state
+    when,
+    when_not,
+    when_any,
+    set_state,
+    is_state,
+    remove_state
 )
 
 from charms.layer.container_runtime_common import (
@@ -20,7 +29,12 @@ from charmhelpers.core import host
 from charmhelpers.core import unitdata
 from charmhelpers.core.templating import render
 from charmhelpers.core.host import install_ca_cert
-from charmhelpers.core.hookenv import status_set, config, log
+from charmhelpers.core.hookenv import (
+    status_set,
+    config,
+    log,
+    env_proxy_settings
+)
 
 from charmhelpers.core.kernel import modprobe
 
@@ -253,6 +267,15 @@ def config_changed():
     # Create "dumb" context based on Config
     # to avoid triggering config.changed.
     context = dict(config())
+
+    # If juju environment variables are defined, take precedent
+    # over config.yaml.
+    # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
+    environment_config = env_proxy_settings()
+    if environment_config is not None:
+        config.update(environment_config)
+
+
     config_file = 'config.toml'
     config_directory = '/etc/containerd'
 

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -268,9 +268,6 @@ def config_changed():
     # to avoid triggering config.changed.
     context = dict(config())
 
-    modified_config = check_for_juju_https_proxy(config)
-    context.update(modified_config)
-
     config_file = 'config.toml'
     config_directory = '/etc/containerd'
 
@@ -315,6 +312,10 @@ def proxy_changed():
     # Create "dumb" context based on Config
     # to avoid triggering config.changed.
     context = dict(config())
+
+    modified_config = check_for_juju_https_proxy(config)
+    context.update(modified_config)
+
     service_file = 'proxy.conf'
     service_directory = '/etc/systemd/system/containerd.service.d'
     service_path = os.path.join(service_directory, service_file)


### PR DESCRIPTION
Changed charm to override http_proxy values with juju-http(s)-proxy values. 

[#LP1831712](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1831712)
