### PR TITLE
Don't block on br_netfilter

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -258,6 +258,15 @@ def publish_config():
 
 @when_not('containerd.br_netfilter.enabled')
 def enable_br_netfilter_module():
-    # Fixes https://github.com/kubernetes/kubernetes/issues/21613
-    modprobe('br_netfilter', persist=True)
+    """
+    Enable br_netfilter to work
+    around https://github.com/kubernetes/kubernetes/issues/21613
+
+    :returns: None
+    """
+    try:
+        modprobe('br_netfilter', persist=True)
+    except Exception as e:  # Kernel probably doesn't support this.
+        log(e)
+
     set_state('containerd.br_netfilter.enabled')

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -1,6 +1,7 @@
 import os
 import json
 import requests
+import traceback
 
 from subprocess import check_call, check_output, CalledProcessError
 
@@ -266,7 +267,11 @@ def enable_br_netfilter_module():
     """
     try:
         modprobe('br_netfilter', persist=True)
-    except Exception as e:  # Kernel probably doesn't support this.
-        log(e)
-
+    except Exception:
+        log(traceback.format_exc())
+        if host.is_container():
+            log('LXD detected, ignoring failure to load br_netfilter')
+        else:
+            log('LXD not detected, will retry loading br_netfilter')
+            return
     set_state('containerd.br_netfilter.enabled')


### PR DESCRIPTION
To avoid 

```bash
modprobe: ERROR: ../libkmod/libkmod.c:586 kmod_search_moddep() could not open moddep file '/lib/modules/4.4.0-143-generic/modules.dep.bin'
modprobe: FATAL: Module br_netfilter not found in directory /lib/modules/4.4.0-143-generic
```
...that I see when deploying into LXD containers.  Blocked on install hook.

I understand that it could result in the bug it was trying to work around, but i'm not sure which is worse.  What do you think @Cynerva?  Maybe we block with a useful message instead?