### PR TITLE
Don't block on br_netfilter

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -1,6 +1,7 @@
 import os
 import json
 import requests
+import traceback
 
 from subprocess import check_call, check_output, CalledProcessError
 
@@ -266,7 +267,11 @@ def enable_br_netfilter_module():
     """
     try:
         modprobe('br_netfilter', persist=True)
-    except Exception as e:  # Kernel probably doesn't support this.
-        log(e)
-
+    except Exception:
+        log(traceback.format_exc())
+        if host.is_container():
+            log('LXD detected, ignoring failure to load br_netfilter')
+        else:
+            log('LXD not detected, will retry loading br_netfilter')
+            return
     set_state('containerd.br_netfilter.enabled')


### PR DESCRIPTION
Suggested improvement to https://github.com/charmed-kubernetes/charm-containerd/pull/10.

If we get an exception where we do expect it (LXD), then don't block, and don't bother retrying.

If we get an exception where we don't expect it, then don't block, but do retry.

I've tested this with cs:~cynerva/containerd-2. Confirmed that br_netfilter is still loading correctly on non-LXD, and that it fails gracefully without blocking on LXD.