### PR TITLE
Docker registry support

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -5,6 +5,7 @@ includes:
   - 'layer:apt'
   - 'layer:container-runtime-common'
   - 'interface:container-runtime'
+  - 'interface:docker-registry'
 options:
   basic:
     packages:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,3 +20,5 @@ requires:
   containerd:
     interface: container-runtime
     scope: container
+  docker-registry:
+    interface: docker-registry

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -368,5 +368,5 @@ def remove_registry():
         log('Disabling auth for docker registry: {}.'.format(
             docker_registry['url']))
 
-    set_state('config.changed')
+    config_changed()
     remove_state('containerd.registry.configured')

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -37,7 +37,7 @@ def _check_containerd():
     """
     Check that containerd is running.
 
-    :returns: Boolean
+    :return: Boolean
     """
     try:
         check_call([
@@ -74,7 +74,7 @@ def enable_br_netfilter_module():
     Enable br_netfilter to work around
     https://github.com/kubernetes/kubernetes/issues/21613
 
-    :returns: None
+    :return: None
     """
     try:
         modprobe('br_netfilter', persist=True)
@@ -96,7 +96,7 @@ def install_containerd():
     by `layer-apt`.  We'll just
     configure it.
 
-    :returns: None
+    :return: None
     """
     config_changed()
 
@@ -190,7 +190,7 @@ def purge_containerd():
     Purge Containerd from the
     cluster.
 
-    :returns: None
+    :return: None
     """
     purge('containerd')
 
@@ -201,7 +201,7 @@ def gpu_config_changed():
     Remove the GPU states when the config
     is changed.
 
-    :returns: None
+    :return: None
     """
     remove_state('containerd.nvidia.ready')
     remove_state('containerd.nvidia.available')
@@ -213,7 +213,7 @@ def config_changed():
     Render the config template
     and restart the service.
 
-    :returns: None
+    :return: None
     """
     # Create "dumb" context based on Config
     # to avoid triggering config.changed.
@@ -257,7 +257,7 @@ def proxy_changed():
     """
     Apply new proxy settings.
 
-    :returns: None
+    :return: None
     """
     # Create "dumb" context based on Config
     # to avoid triggering config.changed.
@@ -295,7 +295,7 @@ def publish_config():
     Pass configuration to principal
     charm.
 
-    :returns: None
+    :return: None
     """
     endpoint = endpoint_from_flag('endpoint.containerd.joined')
     endpoint.set_config(

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -371,7 +371,6 @@ def remove_registry():
         # Remove auth-related data.
         log('Disabling auth for docker registry: {}.'.format(
             docker_registry['url']))
-        manage_registry_certs(cert_dir, remove=True)
 
     set_state('config.changed')
     remove_state('containerd.registry.configured')

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -335,7 +335,7 @@ def configure_registry():
 
     DB.set('registry', docker_registry)
 
-    set_state('config.changed')
+    config_changed()
     set_state('containerd.registry.configured')
 
 

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -51,7 +51,7 @@ def merge_custom_registries(custom_registries):
     Merge custom registries and Docker
     registries from relation.
 
-    :return: Dictionary merge registries
+    :return: List Dictionary merged registries
     """
     registries = []
     registries += json.loads(custom_registries)

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -30,7 +30,6 @@ from charmhelpers.fetch import apt_install, apt_update, import_key
 
 
 DB = unitdata.kv()
-CERTIFICATE_DIRECTORY = '/root/cdk/containerd/certs'
 
 
 def _check_containerd():
@@ -364,9 +363,6 @@ def remove_registry():
         # Remove from DB.
         DB.unset('registry')
         DB.flush()
-
-        # Remove tls-related data.
-        cert_dir = os.path.join(CERTIFICATE_DIRECTORY, docker_registry['url'])
 
         # Remove auth-related data.
         log('Disabling auth for docker registry: {}.'.format(

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -329,9 +329,9 @@ def configure_registry():
         # Ensure the CA that signed our registry cert is trusted.
         install_ca_cert(registry.tls_ca, name='juju-docker-registry')
 
-        docker_registry['ca'] = ca_crt_path
-        docker_registry['key'] = server_key_path
-        docker_registry['cert'] = server_crt_path
+        docker_registry['ca'] = str(ca_crt_path)
+        docker_registry['key'] = str(server_key_path)
+        docker_registry['cert'] = str(server_crt_path)
 
     DB.set('registry', docker_registry)
 

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -60,9 +60,11 @@ oom_score = 0
     {% if custom_registries %}
       [plugins.cri.registry.auths]
       {% for registry in custom_registries %}
+        {% if registry.username and registry.password  %}
         [plugins.cri.registry.auths."{{ registry.url }}"]
           username = "{{ registry.username }}"
           password = "{{ registry.password }}"
+        {% endif %}
       {% endfor %}
     {% endif %}
     [plugins.cri.x509_key_pair_streaming]

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -66,8 +66,6 @@ oom_score = 0
           password = "{{ registry.password }}"
         {% endif %}
       {% endfor %}
-    {% endif %}
-    {% if custom_registries %}
       [plugins.cri.registry.tls_configs]
       {% for registry in custom_registries %}
         {% if registry.ca and registry.cert and registry.key  %}

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -67,6 +67,17 @@ oom_score = 0
         {% endif %}
       {% endfor %}
     {% endif %}
+    {% if custom_registries %}
+      [plugins.cri.registry.tls_configs]
+      {% for registry in custom_registries %}
+        {% if registry.ca and registry.cert and registry.key  %}
+        [plugins.cri.registry.tls_configs."{{ registry.url }}"]
+          ca_file   = "{{ registry.ca }}"
+          cert_file = "{{ registry.cert }}"
+          key_file  = "{{ registry.key }}"
+        {% endif %}
+      {% endfor %}
+    {% endif %}
     [plugins.cri.x509_key_pair_streaming]
       tls_cert_file = ""
       tls_key_file = ""


### PR DESCRIPTION
Bring Docker Registry charm support to Containerd.  Most of the code couldn't be shared between Docker and Containerd due to the differing ways they configure external registries.