### PR TITLE
Add config_changed call after drivers install

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -204,6 +204,7 @@ def configure_nvidia():
     ], fatal=True)
 
     set_state('containerd.nvidia.ready')
+    config_changed()
 
 
 @when('endpoint.containerd.departed')


### PR DESCRIPTION
An issue was uncovered where after nvidia drivers install
the charm does not remove it's 'maintenance' state.

This resolves that by calling config_changed.