### PR TITLE
Add missing charm requirement: requests

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,1 @@
+requests

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,1 @@
-requests
+requests>=2.0.0,<3.0.0


### PR DESCRIPTION
This charm was depending on requests but did not install it in its venv. Due to the previous default for `include_system_packages` of `true`, it was previously relying on the system-wide version. That default changed recently so it's now necessary to include it in the wheelhouse. It's also safer to do so.