### PR TITLE
Fix private registry URL parse error

### DIFF
--- a/templates/config.toml
+++ b/templates/config.toml
@@ -60,10 +60,6 @@ oom_score = 0
       [plugins.cri.registry.mirrors]
         [plugins.cri.registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
-      {% for registry in custom_registries %}
-        [plugins.cri.registry.mirrors."{{ registry.url }}"]
-          endpoint = ["{{ registry.url }}"]
-      {% endfor %}
     {% if custom_registries %}
       [plugins.cri.registry.auths]
       {% for registry in custom_registries %}


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-containerd/+bug/1851850

This error:

```
failed to resolve image "172.16.0.239:5000/pause-amd64:3.1": parse registry endpoint "172.16.0.239:5000": parse 172.16.0.239:5000: first path segment in URL cannot contain colon
```

occurs because the configured mirror endpoint does not include the `https://` scheme like it's supposed to.

We could fix this by adding `https://` to the endpoint config, but actually, the mirror entry in the file seems to serve no purpose -- if the registry is `172.16.0.239:5000`, and there's no mirror defined for it, then it's going to connect to `https://172.16.0.239:5000` anyway.
