### PR TITLE
Fixing LP1865543 and adding docstrings flake8 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install tox-travis
 script:

--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -2,7 +2,8 @@ from charmhelpers.core import hookenv, host, unitdata
 
 
 def get_sandbox_image():
-    '''Return the container image location for the sandbox_image.
+    """
+    Return the container image location for the sandbox_image.
 
     Set an appropriate sandbox image based on known registries. Precedence should be:
     - related docker-registry
@@ -10,7 +11,7 @@ def get_sandbox_image():
     - upstream
 
     :return: str container image location
-    '''
+    """
     db = unitdata.kv()
     canonical_registry = 'rocks.canonical.com:443/cdk'
     upstream_registry = 'k8s.gcr.io'

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -34,6 +34,7 @@ from charmhelpers.core import (
 
 from charmhelpers.core.templating import render
 from charmhelpers.core.hookenv import (
+    atexit,
     status_set,
     config,
     log
@@ -76,10 +77,31 @@ def _check_containerd():
     return True
 
 
+@atexit
+def charm_status():
+    """
+    Set the charm's status after each hook is run.
+
+    :return: None
+    """
+    if is_state('containerd.nvidia.invalid-option'):
+        status_set(
+            'blocked',
+            '{} is an invalid option for gpu_driver'.format(
+                config().get('gpu_driver')
+            )
+        )
+    elif _check_containerd():
+        status_set('active', 'Container runtime available')
+        set_state('containerd.ready')
+
+    else:
+        status_set('blocked', 'Container runtime not available')
+
+
 def merge_custom_registries(custom_registries):
     """
-    Merge custom registries and Docker
-    registries from relation.
+    Merge custom registries and Docker registries from relation.
 
     :return: List Dictionary merged registries
     """
@@ -96,8 +118,7 @@ def merge_custom_registries(custom_registries):
 @when_not('containerd.br_netfilter.enabled')
 def enable_br_netfilter_module():
     """
-    Enable br_netfilter to work around
-    https://github.com/kubernetes/kubernetes/issues/21613
+    Enable br_netfilter to work around https://github.com/kubernetes/kubernetes/issues/21613.
 
     :return: None
     """
@@ -118,8 +139,7 @@ def enable_br_netfilter_module():
           'endpoint.containerd.departed')
 def install_containerd():
     """
-    Install containerd and then create
-    initial configuration.
+    Install containerd and then create initial configuration.
 
     :return: None
     """
@@ -135,8 +155,9 @@ def install_containerd():
 @when_not('endpoint.containerd.departed')
 def check_for_gpu():
     """
-    Check if an Nvidia GPU
-    exists.
+    Check if an Nvidia GPU exists.
+
+    :return: None
     """
     valid_options = [
         'auto',
@@ -146,12 +167,7 @@ def check_for_gpu():
 
     driver_config = config().get('gpu_driver')
     if driver_config not in valid_options:
-        status_set(
-            'blocked',
-            '{} is an invalid option for gpu_driver'.format(
-                driver_config
-            )
-        )
+        set_state('containerd.nvidia.invalid-option')
         return
 
     out = check_output(['lspci', '-nnk']).rstrip().decode('utf-8').lower()
@@ -164,12 +180,18 @@ def check_for_gpu():
             remove_state('containerd.nvidia.available')
             remove_state('containerd.nvidia.ready')
 
+    remove_state('containerd.nvidia.invalid-option')
     set_state('containerd.nvidia.checked')
 
 
 @when('containerd.nvidia.available')
 @when_not('containerd.nvidia.ready', 'endpoint.containerd.departed')
 def configure_nvidia():
+    """
+    Based on charm config, install and configure Nivida drivers.
+
+    :return: None
+    """
     status_set('maintenance', 'Installing Nvidia drivers.')
 
     dist = host.lsb_release()
@@ -178,8 +200,8 @@ def configure_nvidia():
         dist['DISTRIB_RELEASE']
     )
     proxies = {
-       "http": config('http_proxy'),
-       "https": config('https_proxy'),
+        "http": config('http_proxy'),
+        "https": config('https_proxy')
     }
     ncr_gpg_key = requests.get(
         'https://nvidia.github.io/nvidia-container-runtime/gpgkey', proxies=proxies).text
@@ -223,8 +245,7 @@ def configure_nvidia():
 @when('endpoint.containerd.departed')
 def purge_containerd():
     """
-    Purge Containerd from the
-    cluster.
+    Purge Containerd from the cluster.
 
     :return: None
     """
@@ -257,8 +278,7 @@ def purge_containerd():
 @when('config.changed.gpu_driver')
 def gpu_config_changed():
     """
-    Remove the GPU checked state when
-    the config is changed.
+    Remove the GPU checked state when the config is changed.
 
     :return: None
     """
@@ -323,13 +343,6 @@ def config_changed():
     log('Restarting containerd.service')
     host.service_restart('containerd.service')
 
-    if _check_containerd():
-        status_set('active', 'Container runtime available')
-        set_state('containerd.ready')
-
-    else:
-        status_set('blocked', 'Container runtime not available')
-
 
 @when('containerd.ready')
 @when_any('config.changed.http_proxy', 'config.changed.https_proxy',
@@ -376,8 +389,7 @@ def proxy_changed():
 @when_not('endpoint.containerd.departed')
 def publish_config():
     """
-    Pass configuration to principal
-    charm.
+    Pass configuration to principal charm.
 
     :return: None
     """

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -94,7 +94,6 @@ def charm_status():
     elif _check_containerd():
         status_set('active', 'Container runtime available')
         set_state('containerd.ready')
-
     else:
         status_set('blocked', 'Container runtime not available')
 

--- a/tests/test_containerd_lib.py
+++ b/tests/test_containerd_lib.py
@@ -5,6 +5,7 @@ from charms.layer import containerd
 
 
 def patch_fixture(patch_target):
+    """Patch through custom mocks."""
     @pytest.fixture()
     def _fixture():
         with mock.patch(patch_target) as m:
@@ -18,7 +19,7 @@ kv = patch_fixture('charmhelpers.core.unitdata.kv')
 
 
 def test_get_sandbox_image(arch, goal, kv):
-    '''Verify we return a sandbox image from the appropriate registry.'''
+    """Verify we return a sandbox image from the appropriate registry."""
     arch.return_value = 'foo'
     image_name = 'pause-{}:3.1'.format(arch.return_value)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 120
+ignore = D100
 
 [tox]
 skipsdist = True
@@ -7,6 +8,9 @@ envlist = lint,py3
 
 [tox:travis]
 3.5: lint,py3
+3.6: lint, py3
+3.7: lint, py3
+3.8: lint, py3
 
 [testenv]
 basepython = python3
@@ -17,6 +21,7 @@ deps =
     pytest
     pytest-cov
     flake8
+    flake8-docstrings
 commands =
     pytest --cov-report term-missing \
         --cov charms.layer.containerd --cov-fail-under 100 \


### PR DESCRIPTION
Fixing LP1865543 by using the `@atexit` decorator to ensure the charm's
status is always set.

In line with other charms, enabling the flake8-docstrings tests to
ensure they are enforced.