### PR TITLE
LP1866040 charm should set the application version

### DIFF
--- a/actions/upgrade-containerd
+++ b/actions/upgrade-containerd
@@ -12,23 +12,28 @@ from charmhelpers.fetch import (
     apt_unhold
 )
 
-from charmhelpers.core import host
+from charmhelpers.core.host import service_restart
+
+from charms.reactive import remove_state
+
+from reactive.containerd import CONTAINERD_PACKAGE
 
 
 def main():
     """
+    Upgrade containerd to the latest in apt.
+
     :return: None
     """
-    containerd = 'containerd'
-
     try:
         apt_update(fatal=True)
-        apt_unhold(containerd)
-        apt_install(containerd, fatal=True)
-        apt_hold(containerd)
-        host.service_reload(containerd)
+        apt_unhold(CONTAINERD_PACKAGE)
+        apt_install(CONTAINERD_PACKAGE, fatal=True)
+        apt_hold(CONTAINERD_PACKAGE)
+        service_restart(CONTAINERD_PACKAGE)
 
-        action_set({'runtime': containerd})
+        remove_state('containerd.version-published')
+        action_set({'runtime': CONTAINERD_PACKAGE})
 
     except Exception as e:
         action_fail(e)

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -10,6 +10,7 @@ from subprocess import (
 )
 
 from charms.reactive import (
+    hook,
     when,
     when_not,
     when_any,
@@ -115,6 +116,18 @@ def merge_custom_registries(custom_registries):
         registries.append(docker_registry)
 
     return registries
+
+
+@hook('upgrade-charm')
+def upgrade_charm():
+    """
+    Triggered when upgrade-charm is called.
+
+    Prevent containerd being implicitly updated.
+
+    :return: None
+    """
+    apt_hold(CONTAINERD_PACKAGE)
 
 
 @when_not('containerd.br_netfilter.enabled')

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -163,6 +163,8 @@ def publish_version_to_juju():
     :return: None
     """
     version_string = _check_containerd()
+    if not version_string:
+        return
     version = version_string.split()[6].split(b'-')[0].decode()
 
     application_version_set(version)


### PR DESCRIPTION
Re-organising code so that the alive test for containerd can also be
used to get the server version.  Use this to set juju's application
version.

Hold containerd apt package once installed to stop unwanted creep.
Tidy-up upgrade-containerd run-action and make sure it resets juju
application version.