### PR TITLE
update tls template config for containerd 1.3.x

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -124,11 +124,13 @@ def upgrade_charm():
     """
     Triggered when upgrade-charm is called.
 
-    Prevent containerd being implicitly updated.
-
     :return: None
     """
+    # Prevent containerd apt pkg from being implicitly updated.
     apt_hold(CONTAINERD_PACKAGE)
+
+    # Re-render config in case the template has changed in the new charm.
+    config_changed()
 
 
 @when_not('containerd.br_netfilter.enabled')

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -69,10 +69,10 @@ oom_score = 0
           password = "{{ registry.password }}"
         {% endif %}
       {% endfor %}
-      [plugins.cri.registry.tls_configs]
+      [plugins.cri.registry.configs]
       {% for registry in custom_registries %}
         {% if registry.ca and registry.cert and registry.key  %}
-        [plugins.cri.registry.tls_configs."{{ registry.url }}"]
+        [plugins.cri.registry.configs."{{ registry.url }}".tls]
           ca_file   = "{{ registry.ca }}"
           cert_file = "{{ registry.cert }}"
           key_file  = "{{ registry.key }}"


### PR DESCRIPTION
https://bugs.launchpad.net/charm-containerd/+bug/1853653

Containerd updated the `config.toml` sections related to `tls` in 1.3.x:

https://github.com/containerd/cri/pull/1227

This affects our ability to relate `containerd` units to `docker-registry` units that have tls enabled.  This PR updates the config template to use the current 1.3.x syntax.

Without this:
```bash
$ sudo ./crictl --runtime-endpoint=unix:///var/run/containerd/containerd.sock pull 172.31.20.67:5000/defaultbackend-amd64:1.5
FATA[0000] pulling image failed: rpc error: code = Unknown desc = failed to pull and unpack image "172.31.20.67:5000/defaultbackend-amd64:1.5": failed to resolve reference "172.31.20.67:5000/defaultbackend-amd64:1.5": failed to do request: Head https://172.31.20.67:5000/v2/defaultbackend-amd64/manifests/1.5: remote error: tls: bad certificate
```

With it:
```bash
$ sudo ./crictl --runtime-endpoint=unix:///var/run/containerd/containerd.sock pull 172.31.20.67:5000/defaultbackend-amd64:1.5
Image is up to date for sha256:b5af743e598496e8ebd7a6eb3fea76a6464041581520d1c2315c95f993287303
```

**Note 1**: Afaict, `containerd-1.2.x` (which ships with xenial) never supported custom tls with a registry.  Even with these tls bits in the `config.toml` of a xenial deployment, they don't appear in the runtime config:

```bash
$ sudo grep cdk /etc/containerd/config.toml
        ca_file   = "/root/cdk/ca.crt"
        cert_file = "/root/cdk/server.crt"
        key_file  = "/root/cdk/server.key"
$ sudo ./crictl --runtime-endpoint=unix:///var/run/containerd/containerd.sock info | grep cdk
$
```

We *could* introduce a new template variable based on the apt version and only render 1.3 bits when running 1.3.  I didn't do that here because it seemed unnecessary since invalid config is silently ignored. 

**Note 2**: The `auths` section of the `config.toml` has also had a syntax change; the old syntax is deprecated, but still works for 1.3.x.  I opted to leave the old syntax in place to ensure any xenial (containerd 1.2.x) deployments would continue to work if upgraded to this charm.