### PR TITLE
Add support for series upgrade

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -131,6 +131,12 @@ def upgrade_charm():
     config_changed()
 
 
+@hook('pre-series-upgrade')
+def pre_series_upgrade():
+    """Set the status during series upgrade."""
+    status_set('blocked', 'Series upgrade in progress')
+
+
 @when_not('containerd.br_netfilter.enabled')
 def enable_br_netfilter_module():
     """

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -88,7 +88,9 @@ def charm_status():
 
     :return: None
     """
-    if is_state('containerd.nvidia.invalid-option'):
+    if is_state('upgrade.series.in-progress'):
+        status.blocked('Series upgrade in progress')
+    elif is_state('containerd.nvidia.invalid-option'):
         status.blocked(
             '{} is an invalid option for gpu_driver'.format(
                 config().get('gpu_driver')
@@ -129,12 +131,6 @@ def upgrade_charm():
 
     # Re-render config in case the template has changed in the new charm.
     config_changed()
-
-
-@hook('pre-series-upgrade')
-def pre_series_upgrade():
-    """Set the status during series upgrade."""
-    status_set('blocked', 'Series upgrade in progress')
 
 
 @when_not('containerd.br_netfilter.enabled')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
-import sys
-from unittest.mock import MagicMock
+import charms.unit_test
 
-# mock dependencies which we don't care about covering in our tests
-ch = MagicMock()
-sys.modules['charmhelpers'] = ch
-sys.modules['charmhelpers.core'] = ch.core
+
+charms.unit_test.patch_reactive()
+charms.unit_test.patch_module('requests')

--- a/tests/test_containerd_lib.py
+++ b/tests/test_containerd_lib.py
@@ -1,24 +1,15 @@
-import pytest
-from unittest import mock
+from charmhelpers.core.unitdata import kv
+from charmhelpers.core.host import arch
+from charmhelpers.core.hookenv import (
+    goal_state as goal,
+    relation_ids as mock_rids,
+    remote_service_name as mock_remote,
+)
 
 from charms.layer import containerd
 
 
-def patch_fixture(patch_target):
-    """Patch through custom mocks."""
-    @pytest.fixture()
-    def _fixture():
-        with mock.patch(patch_target) as m:
-            yield m
-    return _fixture
-
-
-arch = patch_fixture('charmhelpers.core.host.arch')
-goal = patch_fixture('charmhelpers.core.hookenv.goal_state')
-kv = patch_fixture('charmhelpers.core.unitdata.kv')
-
-
-def test_get_sandbox_image(arch, goal, kv):
+def test_get_sandbox_image():
     """Verify we return a sandbox image from the appropriate registry."""
     arch.return_value = 'foo'
     image_name = 'pause-{}:3.1'.format(arch.return_value)
@@ -35,15 +26,13 @@ def test_get_sandbox_image(arch, goal, kv):
     # No registry and no goal-state: return upstream or canonical depending on remote units
     kv().get.return_value = {}
     goal.side_effect = NotImplementedError()
-    with mock.patch('charmhelpers.core.hookenv.relation_ids') as mock_rids, \
-            mock.patch('charmhelpers.core.hookenv.remote_service_name') as mock_remote:
-        mock_rids.return_value = ['foo']
-        mock_remote.return_value = 'not-kubernetes'
-        assert containerd.get_sandbox_image() == '{}/{}'.format(upstream_registry, image_name)
+    mock_rids.return_value = ['foo']
+    mock_remote.return_value = 'not-kubernetes'
+    assert containerd.get_sandbox_image() == '{}/{}'.format(upstream_registry, image_name)
 
-        mock_rids.return_value = ['foo']
-        mock_remote.return_value = 'kubernetes-master'
-        assert containerd.get_sandbox_image() == '{}/{}'.format(canonical_registry, image_name)
+    mock_rids.return_value = ['foo']
+    mock_remote.return_value = 'kubernetes-master'
+    assert containerd.get_sandbox_image() == '{}/{}'.format(canonical_registry, image_name)
 
     # No registry with k8s in our goal-state: return the canonical image
     kv().get.return_value = {}

--- a/tests/test_containerd_reactive.py
+++ b/tests/test_containerd_reactive.py
@@ -1,8 +1,16 @@
+from unittest.mock import patch
+from charms.reactive import is_state
 from reactive import containerd
 
 
 def test_series_upgrade():
     """Verify series upgrade hook sets the status."""
-    assert containerd.status_set.call_count == 0
-    containerd.pre_series_upgrade()
-    assert containerd.status_set.call_count == 1
+    flags = {
+        'upgrade.series.in-progress': True,
+        'containerd.nvidia.invalid-option': False,
+    }
+    is_state.side_effect = lambda flag: flags[flag]
+    assert containerd.status.blocked.call_count == 0
+    with patch('reactive.containerd._check_containerd', return_value=False):
+        containerd.charm_status()
+    containerd.status.blocked.assert_called_once_with('Series upgrade in progress')

--- a/tests/test_containerd_reactive.py
+++ b/tests/test_containerd_reactive.py
@@ -1,0 +1,8 @@
+from reactive import containerd
+
+
+def test_series_upgrade():
+    """Verify series upgrade hook sets the status."""
+    assert containerd.status_set.call_count == 0
+    containerd.pre_series_upgrade()
+    assert containerd.status_set.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     pytest-cov
     flake8
     flake8-docstrings
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands =
     pytest --cov-report term-missing \
         --cov charms.layer.containerd --cov-fail-under 100 \

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     pytest-cov
     flake8
     flake8-docstrings
+    ipdb
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands =
     pytest --cov-report term-missing \


### PR DESCRIPTION
We can't actually pause the service because the series upgrade hooks run on the subordinates before the principal so doing so could interfere with the pod drain process. So instead, we just set a status to let the Juju admin know that it's ok to proceed.

Part of https://bugs.launchpad.net/charm-containerd/+bug/1869944