### PR TITLE
new containerd restart handler

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -3,6 +3,7 @@ includes:
   - 'layer:basic'
   - 'layer:debug'
   - 'layer:container-runtime-common'
+  - 'layer:status'
   - 'interface:container-runtime'
   - 'interface:untrusted-container-runtime'
   - 'interface:docker-registry'

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -20,7 +20,7 @@ from charms.reactive import (
     endpoint_from_flag
 )
 
-from charms.layer import containerd
+from charms.layer import containerd, status
 from charms.layer.container_runtime_common import (
     ca_crt_path,
     server_crt_path,
@@ -36,7 +36,6 @@ from charmhelpers.core import (
 from charmhelpers.core.templating import render
 from charmhelpers.core.hookenv import (
     atexit,
-    status_set,
     config,
     log,
     application_version_set
@@ -90,17 +89,16 @@ def charm_status():
     :return: None
     """
     if is_state('containerd.nvidia.invalid-option'):
-        status_set(
-            'blocked',
+        status.blocked(
             '{} is an invalid option for gpu_driver'.format(
                 config().get('gpu_driver')
             )
         )
     elif _check_containerd():
-        status_set('active', 'Container runtime available')
+        status.active('Container runtime available')
         set_state('containerd.ready')
     else:
-        status_set('blocked', 'Container runtime not available')
+        status.blocked('Container runtime not available')
 
 
 def merge_custom_registries(custom_registries):
@@ -161,7 +159,7 @@ def install_containerd():
 
     :return: None
     """
-    status_set('maintenance', 'Installing containerd via apt')
+    status.maintenance('Installing containerd via apt')
     apt_update()
     apt_install(CONTAINERD_PACKAGE, fatal=True)
     apt_hold(CONTAINERD_PACKAGE)
@@ -228,7 +226,7 @@ def configure_nvidia():
 
     :return: None
     """
-    status_set('maintenance', 'Installing Nvidia drivers.')
+    status.maintenance('Installing Nvidia drivers.')
 
     dist = host.lsb_release()
     release = '{}{}'.format(
@@ -285,7 +283,7 @@ def purge_containerd():
 
     :return: None
     """
-    status_set('maintenance', 'Removing containerd from principal')
+    status.maintenance('Removing containerd from principal')
 
     host.service_stop('containerd.service')
     apt_unhold(CONTAINERD_PACKAGE)


### PR DESCRIPTION
Fixes [lp 1873477](https://bugs.launchpad.net/charm-containerd/+bug/1873477) and a concern from [layer-container-runtime-common](https://github.com/charmed-kubernetes/layer-container-runtime-common/pull/7#pullrequestreview-395475069).

This PR adds a new `containerd.restart` flag that can be used to restart the containerd service.  This consolidates multiple `host.service_restart` calls into one place, and it also allows other layers to set this flag if they have modified the system in a way that warrants a containerd restart.

Note: I switched over to `layer:status` instead of `hookenv.status_set` because the former will give precedent to blocked > maint > active status messages.  This prevents us from losing a blocked message from a base layer if the charm layer were to `status_set('active', 'foo')`.