### PR TITLE
New event to periodically check for juju model config changes

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -418,7 +418,7 @@ def config_changed():
     set_state('containerd.restart')
 
 
-@when('containerd.ready')
+@when('containerd.installed')
 @when_any('containerd.juju-proxy.changed',
           'config.changed.http_proxy',
           'config.changed.https_proxy',

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -419,10 +419,7 @@ def config_changed():
 
 
 @when('containerd.installed')
-@when_any('containerd.juju-proxy.changed',
-          'config.changed.http_proxy',
-          'config.changed.https_proxy',
-          'config.changed.no_proxy')
+@when('containerd.juju-proxy.changed')
 @when_not('endpoint.containerd.departed')
 def proxy_changed():
     """

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -13,7 +13,6 @@ from charms.reactive import (
     hook,
     when,
     when_not,
-    when_any,
     set_state,
     is_state,
     remove_state,

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -81,6 +81,30 @@ def _check_containerd():
     return version
 
 
+def _juju_proxy_changed():
+    """
+    Check to see if the Juju model
+    HTTP(S) proxy settings have changed.
+
+    These aren't propagated to the charm
+    so we'll need to do it here.
+
+    :return: Boolean
+    """
+    cached = DB.get('config-cache', None)
+    if not cached:
+        return True  # First pass.
+
+    new = check_for_juju_https_proxy(config)
+
+    if cached['http_proxy'] == new ['http_proxy'] and \
+            cached['https_proxy'] == new ['https_proxy'] and \
+            cached['no_proxy'] == new ['no_proxy']:
+        return False
+
+    return True
+
+
 @atexit
 def charm_status():
     """
@@ -117,6 +141,17 @@ def merge_custom_registries(custom_registries):
         registries.append(docker_registry)
 
     return registries
+
+
+@hook('update-status')
+def update_status():
+    """
+    Triggered when update-status is called.
+
+    :return: None
+    """
+    if _juju_proxy_changed:
+        set_state('containerd.juju-proxy.changed')
 
 
 @hook('upgrade-charm')
@@ -331,6 +366,9 @@ def config_changed():
 
     :return: None
     """
+    if _juju_proxy_changed:
+        set_state('containerd.juju-proxy.changed')
+
     # Create "dumb" context based on Config to avoid triggering config.changed
     context = dict(config())
 
@@ -378,11 +416,14 @@ def config_changed():
         context
     )
 
+    DB.set('config-cache', context)
     set_state('containerd.restart')
 
 
 @when('containerd.ready')
-@when_any('config.changed.http_proxy', 'config.changed.https_proxy',
+@when_any('containerd.juju-proxy.changed',
+          'config.changed.http_proxy',
+          'config.changed.https_proxy',
           'config.changed.no_proxy')
 @when_not('endpoint.containerd.departed')
 def proxy_changed():
@@ -404,6 +445,7 @@ def proxy_changed():
 
         os.makedirs(service_directory, exist_ok=True)
 
+        log('Proxy changed, writing new file to {}'.format(service_path))
         render(
             service_file,
             service_path,
@@ -412,10 +454,12 @@ def proxy_changed():
 
     else:
         try:
+            log('Proxy cleaned, removing file {}'.format(service_path))
             os.remove(service_path)
         except FileNotFoundError:
             return  # We don't need to restart the daemon.
 
+    remove_state('containerd.juju-proxy.changed')
     check_call(['systemctl', 'daemon-reload'])
     set_state('containerd.restart')
 

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -83,11 +83,9 @@ def _check_containerd():
 
 def _juju_proxy_changed():
     """
-    Check to see if the Juju model
-    HTTP(S) proxy settings have changed.
+    Check to see if the Juju model HTTP(S) proxy settings have changed.
 
-    These aren't propagated to the charm
-    so we'll need to do it here.
+    These aren't propagated to the charm so we'll need to do it here.
 
     :return: Boolean
     """
@@ -97,9 +95,9 @@ def _juju_proxy_changed():
 
     new = check_for_juju_https_proxy(config)
 
-    if cached['http_proxy'] == new ['http_proxy'] and \
-            cached['https_proxy'] == new ['https_proxy'] and \
-            cached['no_proxy'] == new ['no_proxy']:
+    if cached['http_proxy'] == new['http_proxy'] and \
+            cached['https_proxy'] == new['https_proxy'] and \
+            cached['no_proxy'] == new['no_proxy']:
         return False
 
     return True

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -148,7 +148,7 @@ def update_status():
 
     :return: None
     """
-    if _juju_proxy_changed:
+    if _juju_proxy_changed():
         set_state('containerd.juju-proxy.changed')
 
 

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -364,7 +364,7 @@ def config_changed():
 
     :return: None
     """
-    if _juju_proxy_changed:
+    if _juju_proxy_changed():
         set_state('containerd.juju-proxy.changed')
 
     # Create "dumb" context based on Config to avoid triggering config.changed

--- a/tests/test_containerd_reactive.py
+++ b/tests/test_containerd_reactive.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from charmhelpers.core import unitdata
 from charms.reactive import is_state
 from reactive import containerd
 
@@ -14,3 +15,26 @@ def test_series_upgrade():
     with patch('reactive.containerd._check_containerd', return_value=False):
         containerd.charm_status()
     containerd.status.blocked.assert_called_once_with('Series upgrade in progress')
+
+
+def test_juju_proxy_changed():
+    """Verify proxy changed bools are set as expected."""
+    cached = {'http_proxy': 'foo', 'https_proxy': 'foo', 'no_proxy': 'foo'}
+    new = {'http_proxy': 'bar', 'https_proxy': 'bar', 'no_proxy': 'bar'}
+
+    # Test when nothing is cached
+    db = unitdata.kv()
+    db.get.return_value = None
+    assert containerd._juju_proxy_changed() is True
+
+    # Test when cache hasn't changed
+    db.get.return_value = cached
+    with patch('reactive.containerd.check_for_juju_https_proxy',
+               return_value=cached):
+        assert containerd._juju_proxy_changed() is False
+
+    # Test when cache has changed
+    db.get.return_value = cached
+    with patch('reactive.containerd.check_for_juju_https_proxy',
+               return_value=new):
+        assert containerd._juju_proxy_changed() is True


### PR DESCRIPTION
Addressing https://bugs.launchpad.net/charm-containerd/+bug/1874910

Needed to facilitate `update-status` to periodically check for changes to the Juju model configuration and apply them if necessary.

Tested on CK 1.18 stable with just juju config, just charm config and both together.