### PR TITLE
Cache after proxy merge instead of before

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -444,7 +444,6 @@ def config_changed():
         context
     )
 
-    DB.set('config-cache', context)
     set_state('containerd.restart')
 
 
@@ -483,6 +482,8 @@ def proxy_changed():
             os.remove(service_path)
         except FileNotFoundError:
             return  # We don't need to restart the daemon.
+
+    DB.set('config-cache', context)
 
     remove_state('containerd.juju-proxy.changed')
     check_call(['systemctl', 'daemon-reload'])


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-containerd/+bug/1883663

Tested on CK 1.18 with breakpoints in `_juju_proxy_changed` to check values on startup and when changing proxy values