### PR TITLE
Improve README and config description around custom_registries

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ options:
       to pull images from registries where auth is required.
 
       The value for this config must be a JSON array of credential objects, like this:
-      [{"url": "my.registry:port", "username": "user", "password": "pass"}]
+      [{"host": "my.registry:port", "username": "user", "password": "pass"}]
 
       `host` could be registry host address, e.g.:  myregistry.io:9000, 10.10.10.10:5432.
       or a name, e.g.: myregistry.io, myregistry.

--- a/config.yaml
+++ b/config.yaml
@@ -2,20 +2,31 @@ options:
   custom_registries:
     type: string
     default: "[]"
-    description: |
+    description: |+
       Registry endpoints and credentials. Setting this config allows Kubelet
       to pull images from registries where auth is required.
-      The value for this config must be a JSON array of registry info, like this:
-        '[{"host": "my_registry_1", "url": "http://my.registry:port"}]'.
+
+      The value for this config must be a JSON array of credential objects, like this:
+      [{"url": "my.registry:port", "username": "user", "password": "pass"}]
+
       `host` could be registry host address, e.g.:  myregistry.io:9000, 10.10.10.10:5432.
       or a name, e.g.: myregistry.io, myregistry.
       It will be derived from `url` if not provided, e.g.:
         url: http://10.10.10.10:8000 --> host: 10.10.10.10:8000
+
       If required, you can supply credentials with option keys 'username' and 'password',
       or 'ca_file', 'cert_file', and 'key_file' for ssl/tls communication,
       which should be base64 encoded file contents in string form
 
-      "ca_file": "'$(base64 < my.custom.registry.pem)'"
+      "ca_file": "'"$(base64 -w 0 < my.custom.registry.pem)"'"
+
+      example config)
+      juju config containerd custom_registries='[{
+          "url": "https://registry.example.com",
+          "ca_file": "'"$(base64 -w 0 < ~/my.custom.ca.pem)"'",
+          "cert_file": "'"$(base64 -w 0 < ~/my.custom.cert.pem)"'",
+          "key_file": "'"$(base64 -w 0 < ~/my.custom.key.pem)"'",
+      }]'
   gpu_driver:
     type: string
     default: "auto"

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -168,6 +168,9 @@ def update_custom_tls_config(config_directory, registries, old_registries):
                     log(traceback.format_exc())
                     log("{}:{} didn't look like base64 data... skipping"
                         .format(registry['url'], opt))
+                    status.blocked(
+                        'Invalid base64 data in custom_registries: {}:{}_file'.format(
+                            registry['url'], opt))
                     continue
                 registry[opt] = os.path.join(
                     config_directory, "%s.%s" % (strip_url(registry['url']), opt)

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -168,9 +168,6 @@ def update_custom_tls_config(config_directory, registries, old_registries):
                     log(traceback.format_exc())
                     log("{}:{} didn't look like base64 data... skipping"
                         .format(registry['url'], opt))
-                    status.blocked(
-                        'Invalid base64 data in custom_registries: {}:{}_file'.format(
-                            registry['url'], opt))
                     continue
                 registry[opt] = os.path.join(
                     config_directory, "%s.%s" % (strip_url(registry['url']), opt)


### PR DESCRIPTION
it turns out the README on this was a LITTLE confusing because `base64 < file.pem` can result in a multiline file.  When juju sees this without the correct quoting, it can't see that the config is ALL one single string input.  

the important bit here
```bash
juju config containerd custom_registries='[{
... 
   "ca_file": "'"$(base64 -w 0 < ~/my.custom.ca.pem)"'"
...
}]'
```

this says create a string that had the right json format right up the `"ca_file": "` bit, then append some text that's the output of a command `base64 < ~/my.custom.ca.pem` which could be multi-line text so we'll wrap that in double-quotes then append more text so we need another `'`  and then close that base64 string with a close quote `"`
