### PR TITLE
LP1900881 Strip registry URL for filenames as for the host field

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -126,6 +126,17 @@ def charm_status():
         status.blocked('Container runtime not available')
 
 
+def strip_url(url):
+    """Strip the URL of protocol, slashes etc., and keep host:port.
+
+    Examples:
+        url: http://10.10.10.10:8000 --> return: 10.10.10.10:8000
+        url: https://myregistry.io:8000/ --> return: myregistry.io:8000
+        url: myregistry.io:8000 --> return: myregistry.io:8000
+    """
+    return url.rstrip('/').split(sep='://', maxsplit=1)[-1]
+
+
 def update_custom_tls_config(config_directory, registries):
     """
     Read registries config and write tls files to disk.
@@ -146,7 +157,7 @@ def update_custom_tls_config(config_directory, registries):
                         .format(registry['url'], opt))
                     continue
                 registry[opt] = os.path.join(
-                    config_directory, "%s.%s" % (registry['url'], opt)
+                    config_directory, "%s.%s" % (strip_url(registry['url']), opt)
                 )
                 with open(registry[opt], 'wb') as f:
                     f.write(file_contents)
@@ -167,7 +178,7 @@ def populate_host_for_custom_registries(custom_registries):
             if not registry.get('host'):
                 url = registry.get('url')
                 if url:
-                    registry['host'] = url.rstrip('/').split(sep='://', maxsplit=1)[-1]
+                    registry['host'] = strip_url(url)
 
     return custom_registries
 


### PR DESCRIPTION
The filename for `.ca/.key/.cert` files is based on registry URL.

If it starts with `https://` then `open()` hits `FileNotFoundError`,
and the config-changed hook fails.

Fix this by stripping the URL for the filename as for the `host` field.

Before:

```
	$ juju config containerd custom_registries='[{"url": "https://example.com", "ca_file": "'"$(base64 -w 0 < ca.crt)"'"}]'

	$ juju status | grep containerd
	containerd         1.3.3    error        1  containerd         jujucharms   94  ubuntu
	  containerd/0*       error     idle            10.191.59.168          hook failed: "config-changed"

	$ juju ssh containerd/0 'tail /var/log/juju/unit-containerd-*.log'
	...
	2020-11-06 18:49:27 WARNING config-changed   File "/var/lib/juju/agents/unit-containerd-0/charm/reactive/containerd.py", line 151, in update_custom_tls_config
	2020-11-06 18:49:27 WARNING config-changed     with open(registry[opt], 'wb') as f:
	2020-11-06 18:49:27 WARNING config-changed FileNotFoundError: [Errno 2] No such file or directory: '/etc/containerd/https://example.com.ca'
	2020-11-06 18:49:27 ERROR juju.worker.uniter.operation runhook.go:136 hook "config-changed" (via explicit, bespoke hook script) failed: exit status 1
	2020-11-06 18:49:27 INFO juju.worker.uniter resolver.go:143 awaiting error resolution for "config-changed" hook
	Connection to 10.191.59.168 closed.
```

After:

```
	$ juju config containerd custom_registries='[{"url": "https://another-example.com", "ca_file": "'"$(base64 -w 0 < ca.crt)"'"}]'

	$ juju status | grep containerd
	containerd         1.3.3    active       1  containerd         local         0  ubuntu
	  containerd/0*       active    idle            10.191.59.168          Container runtime available

	$ juju ssh containerd/0 'ls -1 /etc/containerd/*.ca'
	/etc/containerd/another-example.com.ca
```

Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>