### PR TITLE
 LP1901050 Remove TLS files of old custom_registries

### DIFF
--- a/tests/test_containerd_reactive.py
+++ b/tests/test_containerd_reactive.py
@@ -32,7 +32,7 @@ def test_merge_custom_registries():
             "ca_file": "aGVsbG8gd29ybGQgY2EtZmlsZQ==",
             "key_file": "aGVsbG8gd29ybGQga2V5LWZpbGU=",
         }]
-        ctxs = containerd.merge_custom_registries(dir, json.dumps(config))
+        ctxs = containerd.merge_custom_registries(dir, json.dumps(config), None)
         with open(os.path.join(dir, "my.other.registry.ca")) as f:
             assert f.read() == "hello world ca-file"
         with open(os.path.join(dir, "my.other.registry.key")) as f:
@@ -41,6 +41,17 @@ def test_merge_custom_registries():
 
         for ctx in ctxs:
             assert 'url' in ctx
+
+        # Remove 'my.other.registry' from config
+        new_config = [{
+            "url": "my.registry:port",
+            "username": "user",
+            "password": "pass"
+        }]
+        ctxs = containerd.merge_custom_registries(dir, json.dumps(new_config), json.dumps(config))
+        assert not os.path.exists(os.path.join(dir, "my.other.registry.ca"))
+        assert not os.path.exists(os.path.join(dir, "my.other.registry.key"))
+        assert not os.path.exists(os.path.join(dir, "my.other.registry.cert"))
 
 
 def test_juju_proxy_changed():


### PR DESCRIPTION
Upon config changes to the `custom_registries` option, any TLS files
of registries which are no longer in the new config are left behind.

So, check if `custom_registries` changed; if so remove the TLS files
of the old registries.  New registries have TLS files written anyway.
(If it has not changed, no files are removed.)

Note, this does not remove TLS files other than the previous config
(eg, left behind by older versions of the charm, or manually stored.)

Before:
```
	$ echo test >file

	$ juju config containerd custom_registries='[{"url": "registry-one", "ca_file": "'$(base64 <file)'", "key_file": "'$(base64 <file)'", "cert_file": "'$(base64 <file)'"}]'

	$ juju ssh containerd/0 'ls -1 /etc/containerd/'
	config.toml
	registry-one.ca
	registry-one.cert
	registry-one.key
	Connection to 10.191.59.168 closed.

	$ juju config containerd custom_registries='[{"url": "registry-two", "ca_file": "'$(base64 <file)'", "key_file": "'$(base64 <file)'", "cert_file": "'$(base64 <file)'"}]'

	$ juju ssh containerd/0 'ls -1 /etc/containerd/'
	config.toml
	registry-one.ca
	registry-one.cert
	registry-one.key
	registry-two.ca
	registry-two.cert
	registry-two.key
	Connection to 10.191.59.168 closed.
```

After:
```
	$ juju config containerd custom_registries='[{"url": "registry-three", "ca_file": "'$(base64 <file)'", "key_file": "'$(base64 <file)'", "cert_file": "'$(base64 <file)'"}]'

	$ juju ssh containerd/0 'ls -1 /etc/containerd/'
	config.toml
	registry-one.ca
	registry-one.cert
	registry-one.key
	registry-three.ca
	registry-three.cert
	registry-three.key
	Connection to 10.191.59.168 closed.
```

After; with no changes to "custom_registries" / pre-existing TLS files:
```
	$ juju config containerd no_proxy='custom_registries_not_changed.com'

	$ juju ssh containerd/0 'ls -1 /etc/containerd/'
	config.toml
	registry-one.ca
	registry-one.cert
	registry-one.key
	registry-three.ca
	registry-three.cert
	registry-three.key
	Connection to 10.191.59.168 closed.
```

Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>