### PR TITLE
Fix unit tests to work with new unitdata support

### DIFF
--- a/tests/unit/test_containerd_lib.py
+++ b/tests/unit/test_containerd_lib.py
@@ -19,12 +19,10 @@ def test_get_sandbox_image():
     upstream_registry = 'k8s.gcr.io'
 
     # No registry and no k8s in our goal-state: return the upstream image
-    kv().get.return_value = {}
     goal.return_value = {}
     assert containerd.get_sandbox_image() == '{}/{}'.format(upstream_registry, image_name)
 
     # No registry and no goal-state: return upstream or canonical depending on remote units
-    kv().get.return_value = {}
     goal.side_effect = NotImplementedError()
     mock_rids.return_value = ['foo']
     mock_remote.return_value = 'not-kubernetes'
@@ -35,11 +33,10 @@ def test_get_sandbox_image():
     assert containerd.get_sandbox_image() == '{}/{}'.format(canonical_registry, image_name)
 
     # No registry with k8s in our goal-state: return the canonical image
-    kv().get.return_value = {}
     goal.return_value = {'relations': {'containerd': {'kubernetes-master'}}}
     goal.side_effect = None
     assert containerd.get_sandbox_image() == '{}/{}'.format(canonical_registry, image_name)
 
     # A related registry should return registry[url]/image
-    kv().get.return_value = {'url': related_registry}
+    kv().set('registry', {'url': related_registry})
     assert containerd.get_sandbox_image() == '{}/{}'.format(related_registry, image_name)

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -61,17 +61,15 @@ def test_juju_proxy_changed():
 
     # Test when nothing is cached
     db = unitdata.kv()
-    db.get.return_value = None
     assert containerd._juju_proxy_changed() is True
 
     # Test when cache hasn't changed
-    db.get.return_value = cached
+    db.set('config-cache', cached)
     with patch('reactive.containerd.check_for_juju_https_proxy',
                return_value=cached):
         assert containerd._juju_proxy_changed() is False
 
     # Test when cache has changed
-    db.get.return_value = cached
     with patch('reactive.containerd.check_for_juju_https_proxy',
                return_value=new):
         assert containerd._juju_proxy_changed() is True


### PR DESCRIPTION
The charms.unit_test library was updated to include better support for unitdata, removing the need to treat unitdata as a mock.