### PR TITLE
Add support for containerd v2 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,3 @@ QA, and production environments.
 
 This charm is a component of Charmed Kubernetes. For full information,
 please visit the [official Charmed Kubernetes docs](https://www.ubuntu.com/kubernetes/docs/charm-containerd).
-

--- a/README.md
+++ b/README.md
@@ -13,4 +13,3 @@ QA, and production environments.
 This charm is a component of Charmed Kubernetes. For full information,
 please visit the [official Charmed Kubernetes docs](https://www.ubuntu.com/kubernetes/docs/charm-containerd).
 
-Note: This is a fork by Aymen Frikha of cs:~containers/containerd-146 as per LP#1938055

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ QA, and production environments.
 
 This charm is a component of Charmed Kubernetes. For full information,
 please visit the [official Charmed Kubernetes docs](https://www.ubuntu.com/kubernetes/docs/charm-containerd).
+
+Note: This is a fork by Aymen Frikha of cs:~containers/containerd-146 as per LP#1938055

--- a/config.yaml
+++ b/config.yaml
@@ -64,3 +64,12 @@ options:
         addresses) which should be accessed directly, rather than through
         the proxy defined in http_proxy or https_proxy. Must be less than
         2023 characters long.
+  config_version:
+    type: string
+    default: v1
+    description: |
+        (Use carefully, v2 is only tested for nvidia gpu operator)
+        Use config v2 to enable new configuration format.
+        Config file is parsed as version 1 by default.
+        Version 2 uses long plugin names, i.e. "io.containerd.grpc.v1.cri" vs "cri".
+

--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,7 @@ options:
     default: v1
     description: |
         (Use carefully, v2 is only tested for nvidia gpu operator)
-        Use config v2 to enable new configuration format.
+        Use value "v2" for this config parameter to enable new configuration format.
         Config file is parsed as version 1 by default.
         Version 2 uses long plugin names, i.e. "io.containerd.grpc.v1.cri" vs "cri".
 

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -450,6 +450,10 @@ def config_changed():
 
     # Create "dumb" context based on Config to avoid triggering config.changed
     context = dict(config())
+    if context['config_version'] == "v2":
+        template_config = "config_v2.toml"
+    else:
+        template_config = "config.toml"
 
     config_file = 'config.toml'
     config_directory = '/etc/containerd'
@@ -497,7 +501,7 @@ def config_changed():
         context['runtime'] = 'runc'
 
     render(
-        config_file,
+        template_config,
         os.path.join(config_directory, config_file),
         context
     )

--- a/templates/config_v2.toml
+++ b/templates/config_v2.toml
@@ -1,6 +1,7 @@
 root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0
+version = 2
 
 [grpc]
   address = "/run/containerd/containerd.sock"
@@ -23,9 +24,9 @@ oom_score = 0
   path = ""
 
 [plugins]
-  [plugins.cgroups]
+  [plugins."io.containerd.monitor.v1.cgroups"]
     no_prometheus = false
-  [plugins.cri]
+  [plugins."io.containerd.grpc.v1.cri"]
     stream_server_address = "127.0.0.1"
     stream_server_port = "0"
     enable_selinux = false
@@ -34,36 +35,34 @@ oom_score = 0
     systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
-    [plugins.cri.containerd]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
       no_pivot = false
-      [plugins.cri.containerd.default_runtime]
-        runtime_type = "io.containerd.runtime.v1.linux"
 	  {% if untrusted %}
-      [plugins.cri.containerd.untrusted_workload_runtime]
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
         runtime_type= "io.containerd.{{ untrusted_name }}.v2"
 	  {% endif %}
-      [plugins.cri.containerd.runtimes]
-        [plugins.cri.containerd.runtimes.runc]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
           runtime_type = "io.containerd.runc.v1"
 	    {% if untrusted %}
-        [plugins.cri.containerd.runtimes.{{ untrusted_name }}]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ untrusted_name }}]
           runtime_type= "io.containerd.{{ untrusted_name }}.v2"
-          [plugins.cri.containerd.runtimes.{{ untrusted_name }}.options]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ untrusted_name }}.options]
             Runtime = "{{ untrusted_binary }}"
             RuntimeRoot = "{{ untrusted_path }}"
 		{% endif %}
-    [plugins.cri.cni]
+    [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"
       conf_template = ""
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
     {% if custom_registries -%}
       {% for registry in custom_registries -%}
         {% if registry.host -%}
-        [plugins.cri.registry.mirrors."{{ registry.host }}"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry.host }}"]
           {% if registry.url -%}
           endpoint = ["{{ registry.url}}"]
           {% endif -%}
@@ -71,18 +70,18 @@ oom_score = 0
       {% endfor -%}
     {% endif -%}
     {% if custom_registries %}
-      [plugins.cri.registry.auths]
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
       {% for registry in custom_registries %}
         {% if registry.username and registry.password  %}
-        [plugins.cri.registry.auths."{{ registry.url }}"]
+        [plugins."io.containerd.grpc.v1.cri".registry.auths."{{ registry.url }}"]
           username = "{{ registry.username }}"
           password = "{{ registry.password }}"
         {% endif %}
       {% endfor %}
-      [plugins.cri.registry.configs]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
       {% for registry in custom_registries %}
         {% if registry.ca or registry.cert or registry.key or registry.insecure_skip_verify %}
-        [plugins.cri.registry.configs."{{ registry.url }}".tls]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry.url }}".tls]
           ca_file   = "{{ registry.ca if registry.ca else '' }}"
           cert_file = "{{ registry.cert if registry.cert else '' }}"
           key_file  = "{{ registry.key if registry.key else '' }}"
@@ -90,25 +89,24 @@ oom_score = 0
         {% endif %}
       {% endfor %}
     {% endif %}
-    [plugins.cri.x509_key_pair_streaming]
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
       tls_cert_file = ""
       tls_key_file = ""
-  [plugins.diff-service]
+  [plugins."io.containerd.service.v1.diff-service"]
     default = ["walking"]
-  [plugins.linux]
+  [plugins."io.containerd.runtime.v1.linux"]
     shim = "{{ shim }}"
     runtime = "{{ runtime }}"
     runtime_root = ""
     no_shim = false
     shim_debug = false
-  [plugins.opt]
+  [plugins."io.containerd.internal.v1.opt"]
     path = "/opt/containerd"
-  [plugins.restart]
+  [plugins."io.containerd.internal.v1.restart"]
     interval = "10s"
-  [plugins.scheduler]
+  [plugins."io.containerd.gc.v1.scheduler"]
     pause_threshold = 0.02
     deletion_threshold = 0
     mutation_threshold = 100
     schedule_delay = "0s"
     startup_delay = "100ms"
-


### PR DESCRIPTION
These changes are added to be able to support the nvidia gpu operator: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html

The detailed bug/feature request can be found in [LP:#1938055](https://bugs.launchpad.net/charm-containerd/+bug/1938055)
The nvidia gpu operator only supports the v2 config of containerd

