### PR TITLE
Update actions-operator branch name

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@master
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
       - name: Run integration test


### PR DESCRIPTION
Fixes the failure seen in https://github.com/charmed-kubernetes/charm-containerd/actions/runs/1163702094:

```
Error: Unable to resolve action `charmed-kubernetes/actions-operator@master`, unable to find version `master`
```