### PR TITLE
Test templates match expected v1 and v2 rendered configs

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -463,6 +463,10 @@ def gpu_config_changed():
     remove_state('containerd.nvidia.checked')
 
 
+CONFIG_DIRECTORY = '/etc/containerd'
+CONFIG_FILE = 'config.toml'
+
+
 @when('config.changed')
 @when_not('endpoint.containerd.departed')
 def config_changed():
@@ -481,9 +485,6 @@ def config_changed():
     else:
         template_config = "config.toml"
 
-    config_file = 'config.toml'
-    config_directory = '/etc/containerd'
-
     endpoint = endpoint_from_flag('endpoint.containerd.available')
     if endpoint:
         sandbox_image = endpoint.get_sandbox_image()
@@ -495,8 +496,8 @@ def config_changed():
     else:
         context['sandbox_image'] = containerd.get_sandbox_image()
 
-    if not os.path.isdir(config_directory):
-        os.mkdir(config_directory)
+    if not os.path.isdir(CONFIG_DIRECTORY):
+        os.mkdir(CONFIG_DIRECTORY)
 
     # If custom_registries changed, make sure to remove old tls files.
     if config().changed('custom_registries'):
@@ -505,7 +506,7 @@ def config_changed():
         old_custom_registries = None
 
     context['custom_registries'] = \
-        merge_custom_registries(config_directory, context['custom_registries'],
+        merge_custom_registries(CONFIG_DIRECTORY, context['custom_registries'],
                                 old_custom_registries)
 
     untrusted = DB.get('untrusted')
@@ -528,7 +529,7 @@ def config_changed():
 
     render(
         template_config,
-        os.path.join(config_directory, config_file),
+        os.path.join(CONFIG_DIRECTORY, CONFIG_FILE),
         context
     )
 

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -58,7 +58,7 @@ oom_score = 0
       conf_template = ""
     [plugins.cri.registry]
       [plugins.cri.registry.mirrors]
-      {%- if custom_registries %}
+    {%- if custom_registries %}
       {%- for registry in custom_registries %}
         {%- if registry.host %}
         [plugins.cri.registry.mirrors."{{ registry.host }}"]
@@ -66,15 +66,16 @@ oom_score = 0
           endpoint = ["{{ registry.url}}"]
           {%- endif -%}
         {% endif -%}
-      {% endfor%}
-      [plugins.cri.registry.configs]
+      {% endfor %}
+      [plugins.cri.registry.auths]
       {%- for registry in custom_registries %}
         {%- if registry.username and registry.password %}
-        [plugins.cri.registry.configs."{{ registry.url }}".auth]
+        [plugins.cri.registry.auths."{{ registry.url }}"]
           username = "{{ registry.username }}"
           password = "{{ registry.password }}"
         {%- endif -%}
-      {% endfor -%}
+      {% endfor %}
+      [plugins.cri.registry.configs]
       {%- for registry in custom_registries %}
         {%- if registry.ca or registry.cert or registry.key or registry.insecure_skip_verify %}
         [plugins.cri.registry.configs."{{ registry.url }}".tls]
@@ -84,7 +85,7 @@ oom_score = 0
           insecure_skip_verify = {{ "true" if registry.insecure_skip_verify else "false" }}
         {%- endif -%}
       {% endfor -%}
-      {%- endif %}
+    {%- endif %}
     [plugins.cri.x509_key_pair_streaming]
       tls_cert_file = ""
       tls_key_file = ""

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -38,56 +38,53 @@ oom_score = 0
       no_pivot = false
       [plugins.cri.containerd.default_runtime]
         runtime_type = "io.containerd.runtime.v1.linux"
-	  {% if untrusted %}
+      {%- if untrusted %}
       [plugins.cri.containerd.untrusted_workload_runtime]
         runtime_type= "io.containerd.{{ untrusted_name }}.v2"
-	  {% endif %}
+      {% endif %}
       [plugins.cri.containerd.runtimes]
         [plugins.cri.containerd.runtimes.runc]
           runtime_type = "io.containerd.runc.v1"
-	    {% if untrusted %}
+        {%- if untrusted %}
         [plugins.cri.containerd.runtimes.{{ untrusted_name }}]
           runtime_type= "io.containerd.{{ untrusted_name }}.v2"
           [plugins.cri.containerd.runtimes.{{ untrusted_name }}.options]
             Runtime = "{{ untrusted_binary }}"
             RuntimeRoot = "{{ untrusted_path }}"
-		{% endif %}
+        {% endif %}
     [plugins.cri.cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"
       conf_template = ""
     [plugins.cri.registry]
       [plugins.cri.registry.mirrors]
-    {% if custom_registries -%}
-      {% for registry in custom_registries -%}
-        {% if registry.host -%}
+      {%- if custom_registries %}
+      {%- for registry in custom_registries %}
+        {%- if registry.host %}
         [plugins.cri.registry.mirrors."{{ registry.host }}"]
-          {% if registry.url -%}
+          {%- if registry.url %}
           endpoint = ["{{ registry.url}}"]
-          {% endif -%}
+          {%- endif -%}
         {% endif -%}
-      {% endfor -%}
-    {% endif -%}
-    {% if custom_registries %}
-      [plugins.cri.registry.auths]
-      {% for registry in custom_registries %}
-        {% if registry.username and registry.password  %}
-        [plugins.cri.registry.auths."{{ registry.url }}"]
+      {% endfor%}
+      [plugins.cri.registry.configs]
+      {%- for registry in custom_registries %}
+        {%- if registry.username and registry.password %}
+        [plugins.cri.registry.configs."{{ registry.url }}".auth]
           username = "{{ registry.username }}"
           password = "{{ registry.password }}"
-        {% endif %}
-      {% endfor %}
-      [plugins.cri.registry.configs]
-      {% for registry in custom_registries %}
-        {% if registry.ca or registry.cert or registry.key or registry.insecure_skip_verify %}
+        {%- endif -%}
+      {% endfor -%}
+      {%- for registry in custom_registries %}
+        {%- if registry.ca or registry.cert or registry.key or registry.insecure_skip_verify %}
         [plugins.cri.registry.configs."{{ registry.url }}".tls]
           ca_file   = "{{ registry.ca if registry.ca else '' }}"
           cert_file = "{{ registry.cert if registry.cert else '' }}"
           key_file  = "{{ registry.key if registry.key else '' }}"
           insecure_skip_verify = {{ "true" if registry.insecure_skip_verify else "false" }}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
+        {%- endif -%}
+      {% endfor -%}
+      {%- endif %}
     [plugins.cri.x509_key_pair_streaming]
       tls_cert_file = ""
       tls_key_file = ""
@@ -109,4 +106,3 @@ oom_score = 0
     mutation_threshold = 100
     schedule_delay = "0s"
     startup_delay = "100ms"
-

--- a/templates/config_v2.toml
+++ b/templates/config_v2.toml
@@ -37,14 +37,14 @@ version = 2
     max_container_log_line_size = 16384
     [plugins."io.containerd.grpc.v1.cri".containerd]
       no_pivot = false
-	  {% if untrusted %}
+	  {%- if untrusted %}
       [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
         runtime_type= "io.containerd.{{ untrusted_name }}.v2"
-	  {% endif %}
+      {% endif %}
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
           runtime_type = "io.containerd.runc.v1"
-	    {% if untrusted %}
+	    {%- if untrusted %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ untrusted_name }}]
           runtime_type= "io.containerd.{{ untrusted_name }}.v2"
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ untrusted_name }}.options]
@@ -57,36 +57,33 @@ version = 2
       conf_template = ""
     [plugins."io.containerd.grpc.v1.cri".registry]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-    {% if custom_registries -%}
-      {% for registry in custom_registries -%}
-        {% if registry.host -%}
+      {%- if custom_registries -%}
+      {%- for registry in custom_registries -%}
+        {%- if registry.host %}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry.host }}"]
-          {% if registry.url -%}
+          {%- if registry.url %}
           endpoint = ["{{ registry.url}}"]
-          {% endif -%}
+          {%- endif -%}
         {% endif -%}
-      {% endfor -%}
-    {% endif -%}
-    {% if custom_registries %}
-      [plugins."io.containerd.grpc.v1.cri".registry.auths]
-      {% for registry in custom_registries %}
-        {% if registry.username and registry.password  %}
-        [plugins."io.containerd.grpc.v1.cri".registry.auths."{{ registry.url }}"]
-          username = "{{ registry.username }}"
-          password = "{{ registry.password }}"
-        {% endif %}
       {% endfor %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs]
-      {% for registry in custom_registries %}
-        {% if registry.ca or registry.cert or registry.key or registry.insecure_skip_verify %}
+      {%- for registry in custom_registries %}
+        {%- if registry.username and registry.password %}
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry.url }}".auth]
+          username = "{{ registry.username }}"
+          password = "{{ registry.password }}"
+        {%- endif -%}
+      {% endfor -%}
+      {%- for registry in custom_registries %}
+        {%- if registry.ca or registry.cert or registry.key or registry.insecure_skip_verify %}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry.url }}".tls]
           ca_file   = "{{ registry.ca if registry.ca else '' }}"
           cert_file = "{{ registry.cert if registry.cert else '' }}"
           key_file  = "{{ registry.key if registry.key else '' }}"
           insecure_skip_verify = {{ "true" if registry.insecure_skip_verify else "false" }}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
+        {%- endif -%}
+      {% endfor -%}
+    {%- endif %}
     [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
       tls_cert_file = ""
       tls_key_file = ""

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -7,9 +7,17 @@ machines:
   '1':
     constraints: cores=4 mem=4G root-disk=16G
     series: {{ series }}
+  '2':
+    series: {{ series }}
 applications:
   containerd:
     charm: {{ master_charm }}
+  docker-registry:
+    charm: cs:~containers/docker-registry
+    channel: edge
+    num_units: 1
+    to:
+    - '2'
   easyrsa:
     charm: cs:~containers/easyrsa
     channel: edge
@@ -71,3 +79,7 @@ relations:
   - kubernetes-worker:container-runtime
 - - containerd:containerd
   - kubernetes-master:container-runtime
+- - docker-registry:docker-registry
+  - containerd:docker-registry
+- - docker-registry:cert-provider
+  - easyrsa:client

--- a/tests/integration/test_containerd_integration.py
+++ b/tests/integration/test_containerd_integration.py
@@ -64,7 +64,7 @@ async def juju_config(ops_test):
 
 @pytest.fixture(scope="module", params=["v1", "v2"])
 async def config_version(request, juju_config):
-    """Set the containerd config_version based on a parameter to run the same tests various ways."""
+    """Set the containerd config_version based on a parameter."""
     await juju_config('containerd', config_version=request.param)
     return request.param
 

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -1,10 +1,16 @@
+import pathlib
 import os
 import json
 from unittest.mock import patch
+
+import pytest
 from charmhelpers.core import unitdata
+from charmhelpers.core.templating import render
 from charms.reactive import is_state
 from reactive import containerd
 import tempfile
+
+import jinja2
 
 
 def test_series_upgrade():
@@ -52,6 +58,47 @@ def test_merge_custom_registries():
         assert not os.path.exists(os.path.join(dir, "my.other.registry.ca"))
         assert not os.path.exists(os.path.join(dir, "my.other.registry.key"))
         assert not os.path.exists(os.path.join(dir, "my.other.registry.cert"))
+
+
+@pytest.mark.parametrize("version", ("v1", "v2"))
+@patch('reactive.containerd.endpoint_from_flag')
+@patch('reactive.containerd.config')
+def test_custom_registries_render(mock_config, mock_endpoint_from_flag, version):
+    """Verify exact rendering of config.toml files in both v1 and v2 formats."""
+    class MockConfig(dict):
+        def changed(self, *_args, **_kwargs):
+            return False
+
+    def jinja_render(source, target, context):
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader('templates')
+        )
+        template = env.get_template(source)
+        with open(target, 'w') as fp:
+            fp.write(template.render(context))
+
+    render.side_effect = jinja_render
+    config = mock_config.return_value = MockConfig(config_version=version)
+    mock_endpoint_from_flag.return_value.get_sandbox_image.return_value = "sandbox-image"
+    flags = {
+        'containerd.nvidia.available': False,
+    }
+    is_state.side_effect = lambda flag: flags[flag]
+    config['custom_registries'] = json.dumps([{
+        "url": "my.registry:port",
+        "username": "user",
+        "password": "pass"
+    }, {
+        "url": "my.other.registry",
+        "insecure_skip_verify": True
+    }])
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with patch('reactive.containerd.CONFIG_DIRECTORY', tmp_dir):
+            containerd.config_changed()
+        expected = pathlib.Path(__file__).parent / "test_custom_registries_render" / (version + "_config.toml")
+        target = pathlib.Path(tmp_dir) / "config.toml"
+        assert list(target.open()) == list(expected.open())
 
 
 def test_juju_proxy_changed():

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -3,7 +3,6 @@ import os
 import json
 from unittest.mock import patch
 
-import pytest
 from charmhelpers.core import unitdata
 from charmhelpers.core.templating import render
 from charms.reactive import is_state

--- a/tests/unit/test_custom_registries_render/v1_config.toml
+++ b/tests/unit/test_custom_registries_render/v1_config.toml
@@ -53,10 +53,11 @@ oom_score = 0
           endpoint = ["my.registry:port"]
         [plugins.cri.registry.mirrors."my.other.registry"]
           endpoint = ["my.other.registry"]
-      [plugins.cri.registry.configs]
-        [plugins.cri.registry.configs."my.registry:port".auth]
+      [plugins.cri.registry.auths]
+        [plugins.cri.registry.auths."my.registry:port"]
           username = "user"
           password = "pass"
+      [plugins.cri.registry.configs]
         [plugins.cri.registry.configs."my.other.registry".tls]
           ca_file   = ""
           cert_file = ""

--- a/tests/unit/test_custom_registries_render/v1_config.toml
+++ b/tests/unit/test_custom_registries_render/v1_config.toml
@@ -1,0 +1,85 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins.cgroups]
+    no_prometheus = false
+  [plugins.cri]
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    enable_selinux = false
+    sandbox_image = "sandbox-image"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    [plugins.cri.containerd]
+      no_pivot = false
+      [plugins.cri.containerd.default_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+      [plugins.cri.containerd.runtimes]
+        [plugins.cri.containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v1"
+    [plugins.cri.cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins.cri.registry]
+      [plugins.cri.registry.mirrors]
+        [plugins.cri.registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+        [plugins.cri.registry.mirrors."my.registry:port"]
+          endpoint = ["my.registry:port"]
+        [plugins.cri.registry.mirrors."my.other.registry"]
+          endpoint = ["my.other.registry"]
+      [plugins.cri.registry.configs]
+        [plugins.cri.registry.configs."my.registry:port".auth]
+          username = "user"
+          password = "pass"
+        [plugins.cri.registry.configs."my.other.registry".tls]
+          ca_file   = ""
+          cert_file = ""
+          key_file  = ""
+          insecure_skip_verify = true
+    [plugins.cri.x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins.diff-service]
+    default = ["walking"]
+  [plugins.linux]
+    shim = ""
+    runtime = ""
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins.opt]
+    path = "/opt/containerd"
+  [plugins.restart]
+    interval = "10s"
+  [plugins.scheduler]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"

--- a/tests/unit/test_custom_registries_render/v2_config.toml
+++ b/tests/unit/test_custom_registries_render/v2_config.toml
@@ -1,0 +1,84 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+version = 2
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+  [plugins."io.containerd.grpc.v1.cri"]
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    enable_selinux = false
+    sandbox_image = "sandbox-image"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      no_pivot = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v1"
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."my.registry:port"]
+          endpoint = ["my.registry:port"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."my.other.registry"]
+          endpoint = ["my.other.registry"]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."my.registry:port".auth]
+          username = "user"
+          password = "pass"
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."my.other.registry".tls]
+          ca_file   = ""
+          cert_file = ""
+          key_file  = ""
+          insecure_skip_verify = true
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+  [plugins."io.containerd.runtime.v1.linux"]
+    shim = ""
+    runtime = ""
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+  [plugins."io.containerd.gc.v1.scheduler"]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     pytest
     pytest-cov
     ipdb
+    jinja2
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands =
     pytest \


### PR DESCRIPTION
Use unit testing to verify that:
* templates render appropriate v1 and v2 `config.toml`
* adjust template config spacing so generated configs look nicer
* remove deprecated registry 'auths' section with `registry.configs."<url>".auth` instead