### PR TITLE
since pause 3.2, the arch metadata is in effect

### DIFF
--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -1,4 +1,4 @@
-from charmhelpers.core import hookenv, host, unitdata
+from charmhelpers.core import hookenv, unitdata
 
 
 def get_sandbox_image():
@@ -34,4 +34,4 @@ def get_sandbox_image():
         else:
             sandbox_registry = upstream_registry
 
-    return '{}/pause-{}:3.4.1'.format(sandbox_registry, host.arch())
+    return '{}/pause:3.4.1'.format(sandbox_registry)

--- a/tests/unit/test_containerd_lib.py
+++ b/tests/unit/test_containerd_lib.py
@@ -1,5 +1,4 @@
 from charmhelpers.core.unitdata import kv
-from charmhelpers.core.host import arch
 from charmhelpers.core.hookenv import (
     goal_state as goal,
     relation_ids as mock_rids,
@@ -11,8 +10,7 @@ from charms.layer import containerd
 
 def test_get_sandbox_image():
     """Verify we return a sandbox image from the appropriate registry."""
-    arch.return_value = 'foo'
-    image_name = 'pause-{}:3.4.1'.format(arch.return_value)
+    image_name = 'pause:3.4.1'
 
     canonical_registry = 'rocks.canonical.com:443/cdk'
     related_registry = 'my.registry.com:5000'


### PR DESCRIPTION
this no longer needs the arch in the image name

https://github.com/kubernetes/kubernetes/blob/master/build/pause/CHANGELOG.md