### PR TITLE
update nvidia apt key urls to match upstream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -91,7 +91,7 @@ options:
     type: string
     default: |
       https://nvidia.github.io/nvidia-container-runtime/gpgkey
-      https://developer.download.nvidia.com/compute/cuda/repos/{id}{version_id_no_dot}/x86_64/7fa2af80.pub
+      https://developer.download.nvidia.com/compute/cuda/repos/{id}{version_id_no_dot}/x86_64/3bf863cc.pub
     description: |
         Space-separated list of APT GPG key URLs to add when using Nvidia GPUs.
 


### PR DESCRIPTION
https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/

[LP#1971831](https://bugs.launchpad.net/charm-containerd/+bug/)