### PR TITLE
Don't reinstall nvidia packages on nvidia_apt_key_urls change

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,8 +1,8 @@
 name: Run tests with Tox
 
-on: 
+on:
   pull_request:
-    branch: 
+    branch:
       - main
 
 jobs:

--- a/actions/upgrade-actions.py
+++ b/actions/upgrade-actions.py
@@ -23,7 +23,7 @@ from charmhelpers.core.host import service_restart
 
 from charms.reactive import is_state, remove_state
 
-from reactive.containerd import CONTAINERD_PACKAGE, apt_packages, configure_nvidia
+from reactive.containerd import CONTAINERD_PACKAGE, apt_packages, install_nvidia_drivers
 
 
 class ActionError(Exception):
@@ -87,7 +87,7 @@ def _upgrade(containerd, gpu):
             upgrade_list[f"{pkg}.upgrade-complete"] = True
 
         if any(upgrade_list.get(f"{pkg}.upgrade-available") for pkg in _gpu_packages()):
-            configure_nvidia(reconfigure=False)
+            install_nvidia_drivers(reconfigure=False)
             for pkg in _gpu_packages():
                 upgrade_list[f"{pkg}.upgrade-complete"] = True
 

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -549,7 +549,7 @@ def configure_nvidia_sources():
         fetched_keys = fetch_url_text(formatted_key_urls)
         if not all(fetched_keys):
             set_state("containerd.nvidia.fetch_keys_failed")
-            return
+            return False
         remove_state("containerd.nvidia.fetch_keys_failed")
 
         for key in fetched_keys:

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -8,7 +8,7 @@ import yaml
 from charmhelpers.core import unitdata, host
 from charmhelpers.core.templating import render
 from charmhelpers.fetch import import_key
-from charms.reactive import is_state
+from charms.reactive import is_state, set_state
 from reactive import containerd
 import tempfile
 import pytest
@@ -282,13 +282,10 @@ def test_install_nvidia_drivers(
     mock_config_changed,
 ):
     """Verify drivers are removed, config is done, and containerd config is updated."""
+    set_state.reset_mock()
     containerd.install_nvidia_drivers()
     mock_unconfigure_nvidia.assert_called_once_with(reconfigure=False)
     mock_configure_nvidia_sources.assert_called_once_with()
 
     mock_config_changed.assert_called_once_with()
-    flags = {
-        "containerd.nvidia.ready": True,
-        "containerd.nvidia.missing_package_list": True,
-    }
-    is_state.side_effect = lambda flag: flags[flag]
+    set_state.assert_called_once_with("containerd.nvidia.ready")


### PR DESCRIPTION
Change behaviour to where a change in nvidia_apt_key_urls does not trigger a full reinstall of nvidia_apt_packages. Partial fix to LP#1982894