### PR TITLE
configure nvidia sources only if `containerd.nvidia.available`

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -523,11 +523,11 @@ def unconfigure_nvidia(reconfigure=True):
         config_changed()
 
 
-@when("config.changed.nvidia_apt_key_urls")
+@when("containerd.nvidia.available", "config.changed.nvidia_apt_key_urls")
 def configure_nvidia_sources():
     """Configure NVIDIA repositories based on charm config.
 
-    :return: None
+    :return: bool - True if successufully fetched
     """
     status.maintenance("Configuring NVIDIA repositories.")
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
     pytest-operator
     ipdb
     toml
+    juju < 3.0
 commands = 
     pytest --tb native\ 
            --show-capture=no \


### PR DESCRIPTION
* Prevents nvidia_sources config changes (or fresh installs) from an attempted fetch and install of apt sources