### PR TITLE
Add reboot warning if `nvidia-smi` fails.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
     needs:
       - lint-unit
       - call-inclusive-naming-check
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/actions/upgrade-actions.py
+++ b/actions/upgrade-actions.py
@@ -62,7 +62,9 @@ def _dry_run(containerd, gpu):
 
     result = {}
     for name, pkg in search.items():
-        available, installed = map(PkgVersion, (pkg.version, pkg.current_ver.ver_str))
+        current_ver = pkg.current_ver.ver_str if pkg.current_ver else "0.not-installed.0"
+        # there could be a package not install with a current version, assume it needs updating?
+        available, installed = map(PkgVersion, (pkg.version, current_ver))
         result[f"{name}.available"] = available.version
         result[f"{name}.installed"] = installed.version
         result[f"{name}.upgrade-available"] = available > installed

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -177,7 +177,7 @@ def _needs_gpu_reboot() -> bool:
         except CalledProcessError as cpe:
             log("Unable to communicate with the NVIDIA driver.")
             log(cpe)
-            return any(message in cpe.stdout for message in ["Driver/library version mismatch"])
+            return any(message in cpe.stdout.decode() for message in ["Driver/library version mismatch"])
         except FileNotFoundError as fne:
             log("NVIDIA SMI not installed.")
             log(fne)

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -176,9 +176,8 @@ def _needs_gpu_reboot() -> bool:
             check_output(["nvidia-smi"], stderr=STDOUT)
         except CalledProcessError as cpe:
             log("Unable to communicate with the NVIDIA driver.")
-            log(cpe.stdout.decode())
             log(cpe)
-            return True
+            return any(message in cpe.stdout for message in ["Driver/library version mismatch"])
         except FileNotFoundError as fne:
             log("NVIDIA SMI not installed.")
             log(fne)

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -6,7 +6,7 @@ import json
 import re
 import traceback
 
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import check_call, check_output, CalledProcessError, STDOUT
 from typing import List, Mapping, Optional, Set
 import urllib.request
 import urllib.error
@@ -170,6 +170,20 @@ def _juju_proxy_changed():
     return True
 
 
+def _needs_gpu_reboot() -> bool:
+    if is_state("containerd.nvidia.available"):
+        try:
+            check_output(["nvidia-smi"], stderr=STDOUT)
+        except CalledProcessError as cpe:
+            log("Unable to communicate with the NVIDIA driver.")
+            log(cpe.stdout.decode())
+            log(cpe)
+            return True
+        except FileNotFoundError as fne:
+            log("NVIDIA SMI not installed.")
+            log(fne)
+
+
 @atexit
 def charm_status():
     """
@@ -185,6 +199,8 @@ def charm_status():
         status.blocked("Failed to fetch nvidia_apt_key_urls.")
     elif is_state("containerd.nvidia.missing_package_list"):
         status.blocked("No NVIDIA packages selected to install.")
+    elif _needs_gpu_reboot():
+        status.blocked("May need reboot to activate GPU.")
     elif _check_containerd():
         status.active("Container runtime available")
         set_state("containerd.ready")

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -1,6 +1,7 @@
 import pathlib
 import os
 import json
+from subprocess import CalledProcessError, STDOUT
 import unittest.mock as mock
 from urllib.error import HTTPError
 import yaml
@@ -275,6 +276,7 @@ def test_configure_nvidia_sources(mock_open, fetch_url_text):
 @mock.patch.object(containerd, "config_changed")
 @mock.patch.object(containerd, "configure_nvidia_sources")
 @mock.patch.object(containerd, "unconfigure_nvidia")
+@mock.patch.object(containerd, "_test_gpu_reboot", mock.MagicMock())
 @pytest.mark.usefixtures("default_config")
 def test_install_nvidia_drivers(
     mock_unconfigure_nvidia,
@@ -308,3 +310,49 @@ def test_containerd_version(mock_check, mock_version_set):
     mock_check.return_value = version
     containerd.publish_version_to_juju()
     mock_version_set.assert_called_once_with("1.5.9")
+
+
+@mock.patch.object(containerd, "set_state")
+@mock.patch.object(containerd, "remove_state")
+@mock.patch.object(containerd, "is_state")
+@mock.patch.object(containerd, "check_output")
+@pytest.mark.parametrize(
+    "params",
+    [
+        (False, None),
+        (True, None),
+        (True, CalledProcessError(-1, "nvidia-smi", output=b"just a fatal error")),
+        (True, FileNotFoundError),
+    ],
+    ids=[
+        "nvidia not available",
+        "nvidia-smi returns without exception",
+        "nvidia-smi returns with CalledProcessError (non-reboot exception)",
+        "nvidia-smi returns with FileNotFound",
+    ],
+)
+def test_needs_gpu_reboot_false(check_output, is_state, remove_state, set_state, params):
+    nvidia_available, nvidia_smi_exception = params
+    is_state.return_value = nvidia_available
+    check_output.side_effect = nvidia_smi_exception
+
+    assert not containerd._test_gpu_reboot()
+    if not nvidia_available:
+        check_output.assert_not_called()
+    else:
+        check_output.assert_called_once_with(["nvidia-smi"], stderr=STDOUT)
+    set_state.assert_not_called()
+    remove_state.assert_called_once_with("containerd.nvidia.needs_reboot")
+
+
+@mock.patch.object(containerd, "set_state")
+@mock.patch.object(containerd, "remove_state")
+@mock.patch.object(containerd, "is_state")
+@mock.patch.object(containerd, "check_output")
+def test_needs_gpu_reboot_true(check_output, is_state, remove_state, set_state):
+    is_state.return_value = True
+    check_output.side_effect = CalledProcessError(-1, "nvidia-smi", output=b"Driver/library version mismatch")
+    assert containerd._test_gpu_reboot()
+    check_output.assert_called_once_with(["nvidia-smi"], stderr=STDOUT)
+    set_state.assert_called_once_with("containerd.nvidia.needs_reboot")
+    remove_state.assert_not_called()

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -332,6 +332,7 @@ def test_containerd_version(mock_check, mock_version_set):
     ],
 )
 def test_needs_gpu_reboot_false(check_output, is_state, remove_state, set_state, params):
+    """Verify situations where no gpu induced reboot is needed."""
     nvidia_available, nvidia_smi_exception = params
     is_state.return_value = nvidia_available
     check_output.side_effect = nvidia_smi_exception
@@ -350,6 +351,7 @@ def test_needs_gpu_reboot_false(check_output, is_state, remove_state, set_state,
 @mock.patch.object(containerd, "is_state")
 @mock.patch.object(containerd, "check_output")
 def test_needs_gpu_reboot_true(check_output, is_state, remove_state, set_state):
+    """Verify situations where a gpu induced reboot is needed."""
     is_state.return_value = True
     check_output.side_effect = CalledProcessError(-1, "nvidia-smi", output=b"Driver/library version mismatch")
     assert containerd._test_gpu_reboot()

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,10 @@ ignore = D100, W503
 skipsdist = True
 envlist = lint,unit
 
+[testenv]
+setenv =
+  PY_COLORS=1
+
 [testenv:unit]
 basepython = python3
 setenv =


### PR DESCRIPTION
on upgrade of the `cuda-dtrivers`, `nvidia-smi` no longer functions and provides an error which indicates a need for a reboot

This change bubbles out the reboot warning in `juju status` on the unit. 