### PR TITLE
custom_registry config parsed with pydantic

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,8 +23,12 @@ options:
           e.g.: "url": "http://10.10.10.10:8000" --> "host": "10.10.10.10:8000"
 
       username: OPTIONAL str - default ''
-      password: OPTIONAL str - default ''
+      password: OPTIONAL str|dict - default ''
         Used by containerd for basic authentication to the registry.
+        If a string, will be rendered wrapped as a double-quoted str (password = "my-strong-password")
+        If a dictionary, will be rendered as a single-quoted json (password = '{"my": "json"}')
+        e.g.:  "password": '"$(jq -c . gce.json)"'
+
 
       ca_file: OPTIONAL str - default ''
       cert_file: OPTIONAL str - default ''

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -72,7 +72,11 @@ oom_score = 0
         {%- if registry.username and registry.password %}
         [plugins.cri.registry.auths."{{ registry.url }}"]
           username = "{{ registry.username }}"
+          {%- if registry.password is mapping %}
+          password = '{{ registry.password | tojson }}'
+          {%- else -%}
           password = "{{ registry.password }}"
+          {%- endif -%}
         {%- endif -%}
       {% endfor %}
       [plugins.cri.registry.configs]

--- a/templates/config_v2.toml
+++ b/templates/config_v2.toml
@@ -84,7 +84,11 @@ version = 2
         {%- if registry.username and registry.password %}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry.url }}".auth]
           username = "{{ registry.username }}"
+          {%- if registry.password is mapping %}
+          password = '{{ registry.password | tojson }}'
+          {%- else -%}
           password = "{{ registry.password }}"
+          {%- endif -%}
         {%- endif -%}
       {% endfor -%}
       {%- for registry in custom_registries %}

--- a/tests/integration/test_containerd_integration.py
+++ b/tests/integration/test_containerd_integration.py
@@ -15,7 +15,7 @@ async def test_build_and_deploy(ops_test):
     charm = await ops_test.build_charm(".")
 
     overlays = [
-        ops_test.Bundle("kubernetes-core", channel="edge"),
+        ops_test.Bundle("kubernetes-core", channel="1.25/stable"),
         Path("tests/data/charm.yaml"),
     ]
 

--- a/tests/unit/test_custom_registries_render/nvidia-off-v1-config.toml
+++ b/tests/unit/test_custom_registries_render/nvidia-off-v1-config.toml
@@ -56,7 +56,7 @@ oom_score = 0
       [plugins.cri.registry.auths]
         [plugins.cri.registry.auths."my.registry:port"]
           username = "user"
-          password = "pass"
+          password = '{"interesting": "json"}'
       [plugins.cri.registry.configs]
         [plugins.cri.registry.configs."my.other.registry".tls]
           ca_file   = ""

--- a/tests/unit/test_custom_registries_render/nvidia-off-v2-config.toml
+++ b/tests/unit/test_custom_registries_render/nvidia-off-v2-config.toml
@@ -55,7 +55,7 @@ version = 2
       [plugins."io.containerd.grpc.v1.cri".registry.configs]
         [plugins."io.containerd.grpc.v1.cri".registry.configs."my.registry:port".auth]
           username = "user"
-          password = "pass"
+          password = '{"interesting": "json"}'
         [plugins."io.containerd.grpc.v1.cri".registry.configs."my.other.registry".tls]
           ca_file   = ""
           cert_file = ""

--- a/tests/unit/test_custom_registries_render/nvidia-on-v1-config.toml
+++ b/tests/unit/test_custom_registries_render/nvidia-on-v1-config.toml
@@ -56,7 +56,7 @@ oom_score = 0
       [plugins.cri.registry.auths]
         [plugins.cri.registry.auths."my.registry:port"]
           username = "user"
-          password = "pass"
+          password = '{"interesting": "json"}'
       [plugins.cri.registry.configs]
         [plugins.cri.registry.configs."my.other.registry".tls]
           ca_file   = ""

--- a/tests/unit/test_custom_registries_render/nvidia-on-v2-config.toml
+++ b/tests/unit/test_custom_registries_render/nvidia-on-v2-config.toml
@@ -64,7 +64,7 @@ version = 2
       [plugins."io.containerd.grpc.v1.cri".registry.configs]
         [plugins."io.containerd.grpc.v1.cri".registry.configs."my.registry:port".auth]
           username = "user"
-          password = "pass"
+          password = '{"interesting": "json"}'
         [plugins."io.containerd.grpc.v1.cri".registry.configs."my.other.registry".tls]
           ca_file   = ""
           cert_file = ""

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     pytest-cov
     ipdb
     jinja2
+    -rwheelhouse.txt
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands =
     pytest \

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,1 @@
+pydantic


### PR DESCRIPTION
Adjust the custom_registry config parser to handle json objects in the `password` field of a registry to better support gce
[LP#1996778](https://bugs.launchpad.net/charm-containerd/+bug/1996778)


[GCE registries](https://github.com/containerd/cri/blob/master/docs/registry.md#configure-registry-credentials-example---gcr-with-service-account-key-authentication) use a config.toml configuration like this:

where jq is used to generate a single-line json
```bash
jq -c . key.json
```

that's pasted in a the config.toml
```toml
  [plugins."io.containerd.grpc.v1.cri".registry.configs]
    [plugins."io.containerd.grpc.v1.cri".registry.configs."gcr.io".auth]
      username = "_json_key"
      password = 'paste output from jq'
```

The parsing/validation logic for `custom_registry` was complicated, and could be simplified and improved with pydantic.  It also made it trivial to support different config options for the password field to be either a `str` or `dict`
