### PR TITLE
containerd resource binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 *.pyc
 report/
 *.charm
+build-resources.tmp
+containerd-multiarch.tar.gz

--- a/.jujuignore
+++ b/.jujuignore
@@ -1,3 +1,14 @@
 # prevent the following from showing up in the built charm
-.github/
+.coverage
+.tox/
+__pycache__/
+*.pyc
+report/
+*.charm
+build-resources.tmp
+containerd-multiarch.tar.gz
+# beyond .gitignore files
 tests/
+*.pyc
+.github/
+.git/

--- a/actions/upgrade-actions.py
+++ b/actions/upgrade-actions.py
@@ -18,7 +18,7 @@ from charmhelpers.core.host import service_restart
 
 from charms.reactive import is_state, remove_state
 
-from reactive.containerd import CONTAINERD_PACKAGE, apt_packages, containerd_reinstall, install_nvidia_drivers
+from reactive.containerd import CONTAINERD_PACKAGE, apt_packages, reinstall_containerd, install_nvidia_drivers
 
 
 class ActionError(Exception):
@@ -77,7 +77,7 @@ def _upgrade(containerd, gpu):
     try:
         pkg = CONTAINERD_PACKAGE
         if upgrade_list.get(f"{pkg}.upgrade-available"):
-            containerd_reinstall()
+            reinstall_containerd()
             upgrade_list[f"{pkg}.upgrade-complete"] = True
 
         if any(upgrade_list.get(f"{pkg}.upgrade-available") for pkg in _gpu_packages()):

--- a/actions/upgrade-actions.py
+++ b/actions/upgrade-actions.py
@@ -10,12 +10,7 @@ from charmhelpers.core.hookenv import (
     config,
 )
 
-from charmhelpers.fetch import (
-    apt_hold,
-    apt_install,
-    apt_update,
-    apt_unhold,
-)
+from charmhelpers.fetch import apt_update
 
 from charmhelpers.fetch.ubuntu_apt_pkg import PkgVersion
 
@@ -23,7 +18,7 @@ from charmhelpers.core.host import service_restart
 
 from charms.reactive import is_state, remove_state
 
-from reactive.containerd import CONTAINERD_PACKAGE, apt_packages, install_nvidia_drivers
+from reactive.containerd import CONTAINERD_PACKAGE, apt_packages, containerd_reinstall, install_nvidia_drivers
 
 
 class ActionError(Exception):
@@ -82,10 +77,7 @@ def _upgrade(containerd, gpu):
     try:
         pkg = CONTAINERD_PACKAGE
         if upgrade_list.get(f"{pkg}.upgrade-available"):
-            apt_update(fatal=True)
-            apt_unhold(pkg)
-            apt_install(pkg, fatal=True)
-            apt_hold(pkg)
+            containerd_reinstall()
             upgrade_list[f"{pkg}.upgrade-complete"] = True
 
         if any(upgrade_list.get(f"{pkg}.upgrade-available") for pkg in _gpu_packages()):

--- a/build-resources.sh
+++ b/build-resources.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eux
+VERSION="${VERSION:-1.6.10}"
+ARCH="${ARCH:-amd64 arm64 }"
+
+temp_dir="$(readlink -f build-resources.tmp)"
+rm -rf "$temp_dir"
+mkdir "$temp_dir"
+(cd "$temp_dir"
+ for arch in $ARCH; do
+    echo "Download containerd release ${VERSION} for ${arch}"
+    rel_link="https://github.com/containerd/containerd/releases/download/v${VERSION}/containerd-${VERSION}-linux-${arch}.tar.gz"
+    wget $rel_link
+ done
+)
+tar -czvf containerd-multiarch.tar.gz -C "${temp_dir}" .

--- a/build-resources.sh
+++ b/build-resources.sh
@@ -14,4 +14,5 @@ mkdir "$temp_dir"
     wget $rel_link
  done
 )
-tar -czvf containerd-multiarch.tar.gz -C "${temp_dir}" .
+tar -czvf containerd-multiarch.tgz -C "${temp_dir}" .
+rm -rf "$temp_dir"

--- a/layer.yaml
+++ b/layer.yaml
@@ -8,8 +8,10 @@ includes:
   - 'interface:untrusted-container-runtime'
   - 'interface:docker-registry'
 exclude:
+  - .github
   - .coverage
   - .tox
   - __pycache__
   - tests
   - tox.ini
+  - report/

--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -1,13 +1,13 @@
 from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core.hookenv import resource_get
-from functools import cache
+from functools import lru_cache
 import os
 from pathlib import Path
 from subprocess import check_call, check_output, CalledProcessError
 from typing import Union
 
 
-@cache
+@lru_cache
 def arch():
     """Determine current machine's arch."""
     return check_output(["dpkg", "--print-architecture"]).decode().strip()

--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -7,7 +7,7 @@ from subprocess import check_call, check_output, CalledProcessError
 from typing import Union
 
 
-@lru_cache
+@lru_cache()
 def arch():
     """Determine current machine's arch."""
     return check_output(["dpkg", "--print-architecture"]).decode().strip()

--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -9,14 +9,18 @@ from typing import Union
 
 @cache
 def arch():
+    """Determine current machine's arch."""
     return check_output(["dpkg", "--print-architecture"]).decode().strip()
 
 
 class ResourceFailure(Exception):
+    """Custom exception to raise when resource isn't viable."""
+
     pass
 
 
 def unpack_containerd_resource() -> Union[None, Path]:
+    """Unpack containerd resource and provide pathh to parent directory."""
     try:
         archive = resource_get("containerd")
     except Exception:
@@ -25,8 +29,8 @@ def unpack_containerd_resource() -> Union[None, Path]:
     if not archive:
         return ResourceFailure("Missing containerd resource.")
 
-    charm_dir = os.getenv('CHARM_DIR')
-    unpack_path = Path(charm_dir, 'resources', 'containerd')
+    charm_dir = os.getenv("CHARM_DIR")
+    unpack_path = Path(charm_dir, "resources", "containerd")
     return _unpack_archive(archive, unpack_path)
 
 
@@ -38,7 +42,7 @@ def _unpack_archive(archive, unpack_path):
         return None
     if filesize < 10000000:
         return ResourceFailure("Incomplete containerd resource")
-    check_call(['tar', 'xfz', archive, '-C', unpack_path])
+    check_call(["tar", "xfz", archive, "-C", unpack_path])
     return _collect_resource_bins(unpack_path)
 
 

--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -24,10 +24,10 @@ def unpack_containerd_resource() -> Union[None, Path]:
     try:
         archive = resource_get("containerd")
     except Exception:
-        return ResourceFailure("Error fetching the containerd resource.")
+        raise ResourceFailure("Error fetching the containerd resource.")
 
     if not archive:
-        return ResourceFailure("Missing containerd resource.")
+        raise ResourceFailure("Missing containerd resource.")
 
     charm_dir = os.getenv("CHARM_DIR")
     unpack_path = Path(charm_dir, "resources", "containerd")
@@ -41,7 +41,7 @@ def _unpack_archive(archive, unpack_path):
     if filesize == 0:
         return None
     if filesize < 10000000:
-        return ResourceFailure("Incomplete containerd resource")
+        raise ResourceFailure("Incomplete containerd resource")
     check_call(["tar", "xfz", archive, "-C", unpack_path])
     return _collect_resource_bins(unpack_path)
 
@@ -53,7 +53,7 @@ def _collect_resource_bins(unpack_path):
             return _unpack_archive(arch_based, unpack_path)
     bins = list(unpack_path.glob("bin/*"))
     if not bins:
-        return ResourceFailure("containerd resource didn't contain any binaries")
+        raise ResourceFailure("containerd resource didn't contain any binaries")
     for bin in bins:
         if bin.name == "containerd-shim":
             continue  # containerd-shim cannot run with '-v'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,3 +25,54 @@ provides:
   untrusted:
     interface: untrusted-container-runtime
     scope: container
+resources:
+  containerd:
+    type: file
+    filename: containerd.tar.gz
+    description: |-
+      containerd binary release
+      
+      The charm will replace the binaries from
+      the distribution sources with the binaries from 
+      this attached containerd release.
+
+      Container releases can be downloaded from:
+      https://github.com/containerd/containerd/releases
+
+      This tar.gz can either be an arch specific release
+      of containerd or an archive containing 
+      multiple release archives in the top level 
+      with the arch appropriate names.
+
+      ex)
+      juju attach containerd containerd=containerd.tar.gz
+
+      containerd.tar.gz (extracted)
+      └── bin
+          ├── ctr
+          ├── containerd-stress
+          ├── containerd-shim-runc-v2
+          ├── containerd-shim-runc-v1
+          ├── containerd-shim
+          └── containerd
+
+        or
+
+      juju attach containerd containerd=containerd-multiarch.tar.gz
+      containerd-multiarch.tar.gz (extracted)
+      ├── containerd-1.6.10-linux-amd64.tar.gz (extracted)
+      │   └── bin
+      │       ├── ctr
+      │       ├── containerd-stress
+      │       ├── containerd-shim-runc-v2
+      │       ├── containerd-shim-runc-v1
+      │       ├── containerd-shim
+      │       └── containerd
+      └── containerd-1.6.10-linux-arm64.tar.gz (extracted)
+          └── bin
+              ├── ctr
+              ├── containerd-stress
+              ├── containerd-shim-runc-v2
+              ├── containerd-shim-runc-v1
+              ├── containerd-shim
+              └── containerd

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ provides:
 resources:
   containerd:
     type: file
-    filename: containerd.tar.gz
+    filename: containerd.tgz
     description: |-
       containerd binary release
       

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -501,7 +501,7 @@ def install_containerd_resource():
     set_state("containerd.restart")
 
 
-@when("containerd.installed")
+@when("containerd.resource.installed")
 @when_not("containerd.version-published")
 def publish_version_to_juju():
     """

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -465,13 +465,18 @@ def install_containerd():
     :return: None
     """
     status.maintenance("Installing containerd via apt")
-    apt_update()
-    apt_install(CONTAINERD_PACKAGE, fatal=True)
-    apt_hold(CONTAINERD_PACKAGE)
+    reinstall_containerd()
+    config_changed()
 
+
+def reinstall_containerd():
+    """Install and hold containerd with apt."""
+    apt_update(fatal=True)
+    apt_unhold(CONTAINERD_PACKAGE)
+    apt_install(CONTAINERD_PACKAGE, "--reinstall", fatal=True)
+    apt_hold(CONTAINERD_PACKAGE)
     set_state("containerd.installed")
     clear_flag("containerd.resource.installed")
-    config_changed()
 
 
 @when("containerd.installed")

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -132,17 +132,14 @@ register_trigger(when="config.changed.nvidia_apt_packages", clear_flag="containe
 def _check_containerd():
     """
     Check that containerd is running.
-
     `ctr version` calls both client and server side, so is a reasonable indication that everything's been set up
     correctly.
-
     :return: bytes
     """
     try:
         version = check_output(["ctr", "version"])
     except (FileNotFoundError, CalledProcessError):
         return None
-
     return version
 
 
@@ -506,15 +503,13 @@ def install_containerd_resource():
 def publish_version_to_juju():
     """
     Publish the containerd version to Juju.
-
     :return: None
     """
     output = _check_containerd()
     if not output:
         return
-
     output = output.decode()
-    ver_re = re.compile(r"\s*Version:\s+([\d\.]+)")
+    ver_re = re.compile(r"\s*Version:\s+v{0,1}([\d\.]+)")
     version_matches = set(m.group(1) for m in (ver_re.match(line) for line in output.split("\n")) if m)
     if len(version_matches) != 1:
         return

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -132,14 +132,17 @@ register_trigger(when="config.changed.nvidia_apt_packages", clear_flag="containe
 def _check_containerd():
     """
     Check that containerd is running.
+
     `ctr version` calls both client and server side, so is a reasonable indication that everything's been set up
     correctly.
+
     :return: bytes
     """
     try:
         version = check_output(["ctr", "version"])
     except (FileNotFoundError, CalledProcessError):
         return None
+
     return version
 
 
@@ -503,11 +506,13 @@ def install_containerd_resource():
 def publish_version_to_juju():
     """
     Publish the containerd version to Juju.
+
     :return: None
     """
     output = _check_containerd()
     if not output:
         return
+
     output = output.decode()
     ver_re = re.compile(r"\s*Version:\s+v{0,1}([\d\.]+)")
     version_matches = set(m.group(1) for m in (ver_re.match(line) for line in output.split("\n")) if m)

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -473,7 +473,7 @@ def reinstall_containerd():
     """Install and hold containerd with apt."""
     apt_update(fatal=True)
     apt_unhold(CONTAINERD_PACKAGE)
-    apt_install(CONTAINERD_PACKAGE, "--reinstall", fatal=True)
+    apt_install([CONTAINERD_PACKAGE, "--reinstall"], fatal=True)
     apt_hold(CONTAINERD_PACKAGE)
     set_state("containerd.installed")
     clear_flag("containerd.resource.installed")

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -488,6 +488,7 @@ def reinstall_containerd():
 @when_not("containerd.resource.evaluated")
 def install_containerd_resource():
     """Unpack containerd resource charm and install over deb binaries."""
+    status.maintenance("Unpacking containerd resource")
     try:
         bin_path = containerd.unpack_containerd_resource()
     except containerd.ResourceFailure as e:
@@ -500,6 +501,7 @@ def install_containerd_resource():
     if bin_path is None:
         log("An empty tar.gz resource was provided, using deb sources")
     else:
+        status.maintenance("Installing containerd via resource")
         for bin in bin_path.glob("./*"):
             check_call(["install", bin, "/usr/bin/"])
             set_state("containerd.resource.installed")

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -8,7 +8,13 @@ applications:
   docker-registry:
     charm: docker-registry
     channel: edge
-    num_units: 1
+    num_units: 
+  ##  TEMPORARY FIX FOR PASSING INTEGRATION TESTS
+  kubernetes-control-plane:
+    enable-metrics: false
+    controller-manager-extra-args: |-
+      requestheader-client-ca-file=/root/cdk/ca.crt requestheader-allowed-names=system:kube-apiserver,client
+  ################################################
 relations:
 - - docker-registry:docker-registry
   - containerd:docker-registry

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -11,9 +11,10 @@ applications:
     num_units: 
   ##  TEMPORARY FIX FOR PASSING INTEGRATION TESTS
   kubernetes-control-plane:
-    enable-metrics: false
-    controller-manager-extra-args: |-
-      requestheader-client-ca-file=/root/cdk/ca.crt requestheader-allowed-names=system:kube-apiserver,client
+    options:
+      enable-metrics: false
+      controller-manager-extra-args: |-
+        requestheader-client-ca-file=/root/cdk/ca.crt requestheader-allowed-names=system:kube-controller-manager,client
   ################################################
 relations:
 - - docker-registry:docker-registry

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -3,6 +3,8 @@ applications:
   containerd:
     charm: {{charm}}
     channel: null
+    resources:
+      containerd: {{containerd_multiarch|default("0")}}
   docker-registry:
     charm: docker-registry
     channel: edge

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -8,7 +8,7 @@ applications:
   docker-registry:
     charm: docker-registry
     channel: edge
-    num_units: 
+    num_units: 1
   ##  TEMPORARY FIX FOR PASSING INTEGRATION TESTS
   kubernetes-control-plane:
     options:


### PR DESCRIPTION
In preparation for the Charmed Kubernetes 1.26 release, the `containerd` deb from Canonical was pinned on to 1.5.9 on jammy, focal, and bionic. 

In order to have more current compatible binaries for 1.26 kubelet, [LP#1996534](https://bugs.launchpad.net/ubuntu/+source/containerd/+bug/1996534) was opened, but will not be available in time for the release of the charm.  For the initial ck-1.26 the containerd will come with a 1.6.10 release of containerd resource already attached to the charm which supports amd64 and arm64

The charm is being extended to support installing binaries from the upstream [project's releases](https://github.com/containerd/containerd/releases).  A user can download the github release (say 1.6.10) for the target architecture of their cluster and attach it to the charm with:

```bash
juju attach-resource containerd containerd=/path/to/local/containerd-1.6.10-linux-amd64.tar.gz
```

Which will unpack the tar.gz and install the binaries over the existing deb packages.  To remove the resource and restore from the deb sources, one must attach an empty resource.

```bash
touch empty.tgz
juju attach-resource containerd containerd=empty.tgz
```

It is also possible to build a multiarch resource -- see this PR's [build-resources.sh] to see the process.