### PR TITLE
backup containerd release to 1.6.8

### DIFF
--- a/build-resources.sh
+++ b/build-resources.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -eux
-VERSION="${VERSION:-1.6.10}"
+VERSION="${VERSION:-1.6.8}"
 ARCH="${ARCH:-amd64 arm64 }"
 
 temp_dir="$(readlink -f build-resources.tmp)"

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
     toml
     juju < 3.0
 commands = 
-    pytest --tb native\
+    pytest --tb native \
            --show-capture=no \
            --asyncio-mode=auto \
            --log-cli-level=INFO \


### PR DESCRIPTION
Requires rebuild of docker-registry charm after merging the following:
* https://github.com/canonical/docker-registry-charm/pull/66