### PR TITLE
[LP#2002593] detect presence of cgroup2, and apply to containerd config if available

### DIFF
--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -1,7 +1,9 @@
-from charmhelpers.core import hookenv, unitdata
-from charmhelpers.core.hookenv import resource_get
-from functools import lru_cache
 import os
+import traceback
+
+from charmhelpers.core import hookenv, unitdata
+from charmhelpers.core.hookenv import resource_get, log
+from functools import lru_cache
 from pathlib import Path
 from subprocess import check_call, check_output, CalledProcessError
 from typing import Union
@@ -24,6 +26,8 @@ def can_mount_cgroup2() -> bool:
     try:
         stdout = check_output(["mount", "-t", "cgroup2"], text=True)
     except CalledProcessError:
+        msg = "Failed to find mount type cgroup2\n" + traceback.format_exc()
+        log(msg, level=hookenv.ERROR)
         return False
     return "type cgroup2" in stdout
 

--- a/lib/charms/layer/containerd.py
+++ b/lib/charms/layer/containerd.py
@@ -19,6 +19,15 @@ class ResourceFailure(Exception):
     pass
 
 
+def can_mount_cgroup2() -> bool:
+    """Determine if it's possible to mount cgroup2 type filesystems."""
+    try:
+        stdout = check_output(["mount", "-t", "cgroup2"], text=True)
+    except CalledProcessError:
+        return False
+    return "type cgroup2" in stdout
+
+
 def unpack_containerd_resource() -> Union[None, Path]:
     """Unpack containerd resource and provide pathh to parent directory."""
     try:

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -730,6 +730,12 @@ def config_changed():
     else:
         template_config = "config.toml"
 
+    # Configure runtime type
+    context["runtime_type"] = "io.containerd.runc.v2"
+
+    if not containerd.can_mount_cgroup2():
+        context["runtime_type"] = "io.containerd.runc.v1"
+
     endpoint = endpoint_from_flag("endpoint.containerd.available")
     if endpoint:
         sandbox_image = endpoint.get_sandbox_image()

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -44,7 +44,7 @@ oom_score = 0
       {% endif %}
       [plugins.cri.containerd.runtimes]
         [plugins.cri.containerd.runtimes.runc]
-          runtime_type = "io.containerd.runc.v1"
+          runtime_type = "{{ runtime_type }}"
         {%- if untrusted %}
         [plugins.cri.containerd.runtimes.{{ untrusted_name }}]
           runtime_type= "io.containerd.{{ untrusted_name }}.v2"

--- a/templates/config_v2.toml
+++ b/templates/config_v2.toml
@@ -46,7 +46,7 @@ version = 2
       {% endif %}
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-          runtime_type = "io.containerd.runc.v1"
+          runtime_type = "{{ runtime_type }}"
       {%- if untrusted %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ untrusted_name }}]
           runtime_type= "io.containerd.{{ untrusted_name }}.v2"

--- a/tests/unit/test_containerd_lib.py
+++ b/tests/unit/test_containerd_lib.py
@@ -1,3 +1,6 @@
+import pytest
+import subprocess
+
 from charmhelpers.core.unitdata import kv
 from charmhelpers.core.hookenv import (
     goal_state as goal,
@@ -6,6 +9,7 @@ from charmhelpers.core.hookenv import (
 )
 
 from charms.layer import containerd
+from unittest import mock
 
 
 def test_get_sandbox_image():
@@ -38,3 +42,25 @@ def test_get_sandbox_image():
     # A related registry should return registry[url]/image
     kv().set("registry", {"url": related_registry})
     assert containerd.get_sandbox_image() == "{}/{}".format(related_registry, image_name)
+
+
+@mock.patch.object(containerd, "check_output")
+def test_can_mount_cgroup2(mock_check_output):
+    """Verifies the library method `can_mount_cgroup2`."""
+    found = "cgroup2 on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime)"
+    subprocess_failure = subprocess.CalledProcessError(
+        returncode=1, cmd=["mount", "-t", "cgroup2"], stderr="mock error response"
+    )
+
+    mock_check_output.return_value = ""
+    assert not containerd.can_mount_cgroup2()
+
+    mock_check_output.return_value = found
+    assert containerd.can_mount_cgroup2()
+
+    mock_check_output.side_effect = subprocess_failure
+    assert not containerd.can_mount_cgroup2()
+
+    with pytest.raises(FileNotFoundError):
+        mock_check_output.side_effect = FileNotFoundError("mount")
+        containerd.can_mount_cgroup2()

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -121,6 +121,7 @@ def test_merge_custom_registries():
 @pytest.mark.parametrize("gpu", ("off", "on"), ids=("gpu off", "gpu on"))
 @mock.patch("reactive.containerd.endpoint_from_flag")
 @mock.patch("reactive.containerd.config")
+@mock.patch("charms.layer.containerd.can_mount_cgroup2", mock.Mock(return_value=False))
 def test_custom_registries_render(mock_config, mock_endpoint_from_flag, gpu, version):
     """Verify exact rendering of config.toml files in both v1 and v2 formats."""
 


### PR DESCRIPTION
[lp#2002593](https://bugs.launchpad.net/charm-containerd/+bug/2002593)

Eliminate warnings in /var/log/syslog which create 230k lines per day under certain conditions

```
cgroup v2 not implemented for Stats: not implemented
```