### PR TITLE
install nvidia-drivers with `--no-install-recommends` option

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,8 @@ jobs:
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-          bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
+          juju-channel: "3.1/stable"
+          bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run integration test
         run: tox -e integration -- --model-config=.github/data/proxy_config.yaml
       - name: Setup Debug Artifact Collection

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,7 @@ jobs:
           juju-channel: "3.1/stable"
           bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run integration test
-        run: tox -e integration -- --model-config=.github/data/proxy_config.yaml
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest --model-config=.github/data/proxy_config.yaml
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -663,8 +663,8 @@ def install_nvidia_drivers(reconfigure=True):
     remove_state("containerd.nvidia.missing_package_list")
 
     options = [
-        '--option=Dpkg::Options::=--force-confold',
-        '--no-install-recommends',
+        "--option=Dpkg::Options::=--force-confold",
+        "--no-install-recommends",
     ]
     apt_install(nvidia_packages, fatal=True, options=options)
     # Prevent nvidia packages from being automatically updated.
@@ -832,7 +832,6 @@ def proxy_changed():
     service_path = os.path.join(service_directory, service_file)
 
     if context.get("http_proxy") or context.get("https_proxy") or context.get("no_proxy"):
-
         os.makedirs(service_directory, exist_ok=True)
 
         log("Proxy changed, writing new file to {}".format(service_path))

--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -662,7 +662,11 @@ def install_nvidia_drivers(reconfigure=True):
         return
     remove_state("containerd.nvidia.missing_package_list")
 
-    apt_install(nvidia_packages, fatal=True)
+    options = [
+        '--option=Dpkg::Options::=--force-confold',
+        '--no-install-recommends',
+    ]
+    apt_install(nvidia_packages, fatal=True, options=options)
     # Prevent nvidia packages from being automatically updated.
     apt_hold(nvidia_packages)
     _test_gpu_reboot()

--- a/tests/integration/test_containerd_integration.py
+++ b/tests/integration/test_containerd_integration.py
@@ -177,7 +177,7 @@ async def juju_config(ops_test):
     for app, (pre_test, settable, timeout) in to_revert.items():
         revert_config = {key: pre_test[key]["value"] for key in settable}
         await ops_test.model.applications[app].set_config(revert_config)
-    await ops_test.model.wait_for_idle(apps=list(to_revert.keys()), status="active", timeout=timeout)
+    await ops_test.model.wait_for_idle(apps=list(to_revert.keys()), status="active")
 
 
 @pytest.fixture(scope="module", params=["v1", "v2"])


### PR DESCRIPTION
[LP#2017175](https://bugs.launchpad.net/charm-containerd/+bug/2017175)

 to prevent extra gnome packages
[without this flag](https://paste.ubuntu.com/p/YTm3c7cCGM/) - 21 gnome packages

[with the flag](https://paste.ubuntu.com/p/9TvRfkmnj7/)  - 9 gnome packages

[including policy-kit-1-gnome](https://paste.ubuntu.com/p/fyKS4HxSVC/) - 0 gnome packages
