### PR TITLE
Update libnvidia-container apt repo url

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -114,7 +114,7 @@ options:
   nvidia_apt_sources:
     type: string
     default: |
-      deb https://nvidia.github.io/libnvidia-container/{id}{version_id}/$(ARCH) /
+      deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
       deb https://nvidia.github.io/nvidia-container-runtime/{id}{version_id}/$(ARCH) /
       deb https://developer.download.nvidia.com/compute/cuda/repos/{id}{version_id_no_dot}/x86_64 /
     description: |

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -316,7 +316,7 @@ def test_configure_nvidia_sources(mock_open, fetch_url_text):
     mock_open.assert_called_once_with("/etc/apt/sources.list.d/nvidia.list", "w")
     mock_file = mock_open.return_value.__enter__()
     mock_file.write.assert_called_once_with(
-        "deb https://nvidia.github.io/libnvidia-container/ubuntu20.04/$(ARCH) /\n"
+        "deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /\n"
         "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu20.04/$(ARCH) /\n"
         "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /"
     )


### PR DESCRIPTION
Fixes: [LP#2034080](https://launchpad.net/bugs/2034080)

Per the [1.14.0 release notes](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/release-notes.html#fixes-and-features), deb packages for all supported distributions will be distributed via a singular "deb" repo.