### PR TITLE
[LP#1991010] Test that the reboot is necessary until the smi functions

### DIFF
--- a/reactive/containerd.py
+++ b/reactive/containerd.py
@@ -170,6 +170,7 @@ def _juju_proxy_changed():
     return True
 
 
+@when("containerd.nvidia.needs_reboot")
 def _test_gpu_reboot() -> bool:
     reboot = False
     if is_state("containerd.nvidia.available"):


### PR DESCRIPTION
After a reboot, the `nvidia-smi` package will function, but nothing clears the flag indicating it needs a reboot.  Let's keep testing that this is broken until the `nvidia-smi` application no longer fails