### PR TITLE
Add config option for `device_ownership_from_security_context` flag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -129,3 +129,8 @@ options:
     default: "cuda-drivers nvidia-container-runtime"
     description: |
         Space-separated list of APT packages to install when using Nvidia GPUs.
+  device_ownership_from_security_context:
+    type: boolean
+    default: false
+    description: |
+        Opt-in entry to allow non-root containers to use devices.

--- a/templates/config_v2.toml
+++ b/templates/config_v2.toml
@@ -35,6 +35,9 @@ version = 2
     systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
+    {%- if device_ownership_from_security_context %}
+    device_ownership_from_security_context = true
+    {%- endif %}
     [plugins."io.containerd.grpc.v1.cri".containerd]
       no_pivot = false
       {%- if runtime.lower() != "runc" %}

--- a/tests/unit/test_custom_registries_render/device-ownership-False-v2-config.toml
+++ b/tests/unit/test_custom_registries_render/device-ownership-False-v2-config.toml
@@ -1,0 +1,94 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+version = 2
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+  [plugins."io.containerd.grpc.v1.cri"]
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    enable_selinux = false
+    sandbox_image = "sandbox-image"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      no_pivot = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v1"
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."my.registry:port"]
+          endpoint = ["my.registry:port"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."my.other.registry"]
+          endpoint = ["my.other.registry"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."db.registry:5000"]
+          endpoint = ["http://db.registry:5000"]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."my.registry:port".auth]
+          username = "user"
+          password = '{"interesting": "json"}'
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."http://db.registry:5000".auth]
+          username = "user"
+          password = "pass"
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."my.other.registry".tls]
+          ca_file   = ""
+          cert_file = ""
+          key_file  = ""
+          insecure_skip_verify = true
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."http://db.registry:5000".tls]
+          ca_file   = "/known/file/path/ca.crt"
+          cert_file = "/known/file/path/cert.crt"
+          key_file  = "/known/file/path/cert.key"
+          insecure_skip_verify = false
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+  [plugins."io.containerd.runtime.v1.linux"]
+    shim = ""
+    runtime = "runc"
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+  [plugins."io.containerd.gc.v1.scheduler"]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"

--- a/tests/unit/test_custom_registries_render/device-ownership-True-v2-config.toml
+++ b/tests/unit/test_custom_registries_render/device-ownership-True-v2-config.toml
@@ -1,0 +1,95 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+version = 2
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+  [plugins."io.containerd.grpc.v1.cri"]
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    enable_selinux = false
+    sandbox_image = "sandbox-image"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    device_ownership_from_security_context = true
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      no_pivot = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v1"
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."my.registry:port"]
+          endpoint = ["my.registry:port"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."my.other.registry"]
+          endpoint = ["my.other.registry"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."db.registry:5000"]
+          endpoint = ["http://db.registry:5000"]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."my.registry:port".auth]
+          username = "user"
+          password = '{"interesting": "json"}'
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."http://db.registry:5000".auth]
+          username = "user"
+          password = "pass"
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."my.other.registry".tls]
+          ca_file   = ""
+          cert_file = ""
+          key_file  = ""
+          insecure_skip_verify = true
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."http://db.registry:5000".tls]
+          ca_file   = "/known/file/path/ca.crt"
+          cert_file = "/known/file/path/cert.crt"
+          key_file  = "/known/file/path/cert.key"
+          insecure_skip_verify = false
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+  [plugins."io.containerd.runtime.v1.linux"]
+    shim = ""
+    runtime = "runc"
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+  [plugins."io.containerd.gc.v1.scheduler"]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"


### PR DESCRIPTION
When deploying KubeVirt and the containerized data importer (CDI) the opt-in config entry `device_ownership_from_security_context` must be set for the CRI in order to allow non-root containers to consume (block) devices.
https://github.com/kubevirt/containerized-data-importer/blob/f5d0b70b096abd856acff67eb4fc0cab0b474d89/doc/block_cri_ownership_config.md