### PR TITLE
Upgrade to 1.7.28

### DIFF
--- a/build-resources.sh
+++ b/build-resources.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -eux
-VERSION="${VERSION:-1.6.38}"
+VERSION="${VERSION:-1.7.28}"
 ARCH="${ARCH:-amd64 arm64 }"
 
 temp_dir="$(readlink -f build-resources.tmp)"

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -115,7 +115,6 @@ options:
     type: string
     default: |
       deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
-      deb https://nvidia.github.io/nvidia-container-runtime/{id}{version_id}/$(ARCH) /
       deb https://developer.download.nvidia.com/compute/cuda/repos/{id}{version_id_no_dot}/x86_64 /
     description: |
         Newline-separated list of APT sources to add when using Nvidia GPUs.

--- a/src/lib/charms/layer/containerd.py
+++ b/src/lib/charms/layer/containerd.py
@@ -1,5 +1,6 @@
 import os
 import traceback
+import shutil
 
 from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core.hookenv import resource_get, log
@@ -44,6 +45,7 @@ def unpack_containerd_resource() -> Union[None, Path]:
 
     charm_dir = os.getenv("CHARM_DIR")
     unpack_path = Path(charm_dir, "resources", "containerd")
+    shutil.rmtree(unpack_path, ignore_errors=True)
     return _unpack_archive(archive, unpack_path)
 
 

--- a/src/lib/charms/layer/containerd.py
+++ b/src/lib/charms/layer/containerd.py
@@ -68,8 +68,8 @@ def _collect_resource_bins(unpack_path):
     if not bins:
         raise ResourceFailure("containerd resource didn't contain any binaries")
     for bin in bins:
-        if bin.name == "containerd-shim":
-            continue  # containerd-shim cannot run with '-v'
+        if bin.name in ["containerd-shim", "containerd-stress"]:
+            continue  # applications which cannot run with '-v'
         try:
             check_call([bin, "-v"])
         except CalledProcessError:

--- a/src/reactive/containerd.py
+++ b/src/reactive/containerd.py
@@ -922,6 +922,7 @@ def restart_containerd():
     status.maintenance("Restarting containerd")
     if host.service_restart("containerd.service"):
         remove_state("containerd.restart")
+        remove_state("containerd.version-published")
     else:
         log("Failed to restart containerd; will retry")
 

--- a/src/reactive/containerd.py
+++ b/src/reactive/containerd.py
@@ -654,7 +654,7 @@ def unconfigure_nvidia(reconfigure=True):
 def configure_nvidia_sources():
     """Configure NVIDIA repositories based on charm config.
 
-    :return: bool - True if successufully fetched
+    :return: bool - True if successfully fetched
     """
     status.maintenance("Configuring NVIDIA repositories.")
 

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,2 +1,3 @@
 charms.reactive==1.5.3
 setuptools==70.3.0
+setuptools_scm==6.4.2

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -317,7 +317,6 @@ def test_configure_nvidia_sources(mock_open, fetch_url_text):
     mock_file = mock_open.return_value.__enter__()
     mock_file.write.assert_called_once_with(
         "deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /\n"
-        "deb https://nvidia.github.io/nvidia-container-runtime/ubuntu20.04/$(ARCH) /\n"
         "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /"
     )
 


### PR DESCRIPTION
### Overview
Upgrade from 1.6 -> 1.7 containerd

### Details
* pinning of python package
* ignore version check on `containerd_stress`
* ensure resource changes trigger the charm application version to be updated