### PR TITLE
[LP#2143365] When containerd is installed by resource, don't restart service with apt

### DIFF
--- a/src/reactive/containerd.py
+++ b/src/reactive/containerd.py
@@ -52,6 +52,7 @@ from charmhelpers.fetch import (
 from charmhelpers.fetch.ubuntu_apt_pkg import Package
 
 NVIDIA_SOURCES_FILE = "/etc/apt/sources.list.d/nvidia.list"
+NEEDRESTART_SUSPEND = "NEEDRESTART_SUSPEND"
 
 
 def apt_packages(packages: typing.Set[str]) -> typing.Mapping[str, Package]:
@@ -526,22 +527,21 @@ def _apt_restart_services(restart: bool):
     """
     Context manager to conditionally restart services after apt operations.
 
-    Args:
-        restart: whether to restart services after apt operations
+    :param bool restart: whether to restart services after apt operations
     """
-    original = os.environ.get("NEEDRESTART_SUSPEND")
-    log("Services will {}be restarted after apt operations.".format("" if restart else "not "))
+    env = NEEDRESTART_SUSPEND
+    original = os.environ.pop(env, None)
+    log(f"Services will {'' if restart else 'not '}be restarted after apt operations.")
     if not restart:
-        os.environ.update({"NEEDRESTART_SUSPEND": "1"})
-    else:
-        os.environ.pop("NEEDRESTART_SUSPEND", None)
+        os.environ.update({env: "1"})
+
     try:
         yield
     finally:
         if original is None:
-            os.environ.pop("NEEDRESTART_SUSPEND", None)
+            os.environ.pop(env, None)
         else:
-            os.environ["NEEDRESTART_SUSPEND"] = original
+            os.environ[env] = original
 
 
 def reinstall_containerd(restart: bool = True):

--- a/src/reactive/containerd.py
+++ b/src/reactive/containerd.py
@@ -468,7 +468,10 @@ def upgrade_charm():
     if is_state("containerd.resource.installed"):
         # if a resource is currently overriding the deb,
         # upgrade containerd from the apt packages
-        reinstall_containerd()
+        # to make sure we get latest systemd services, latest configs,
+        # and dependencies like runc if needed -- but don't restart into
+        # those services
+        reinstall_containerd(restart=False)
 
     # Re-render config in case the template has changed in the new charm.
     config_changed()
@@ -518,11 +521,28 @@ def install_containerd():
     config_changed()
 
 
-def reinstall_containerd():
+@contextlib.contextmanager
+def _apt_restart_services(restart: bool):
+    """
+    Context manager to conditionally restart services after apt operations.
+
+    :param restart: whether to restart services after apt operations
+    """
+    restore = os.environ.pop("NEEDRESTART_SUSPEND", None)
+    if not restart:
+        log("Services will be not restarted after apt operations.")
+        os.environ.update({"NEEDRESTART_SUSPEND": "1"})
+    yield
+    if restore is not None:
+        os.environ["NEEDRESTART_SUSPEND"] = restore
+
+
+def reinstall_containerd(restart: bool = True):
     """Install and hold containerd with apt."""
     apt_update(fatal=True)
     apt_unhold(CONTAINERD_PACKAGE)
-    apt_install([CONTAINERD_PACKAGE, "--reinstall"], fatal=True)
+    with _apt_restart_services(restart):
+        apt_install([CONTAINERD_PACKAGE, "--reinstall"], fatal=True)
     apt_hold(CONTAINERD_PACKAGE)
     set_state("containerd.installed")
     remove_state("containerd.resource.evaluated")

--- a/src/reactive/containerd.py
+++ b/src/reactive/containerd.py
@@ -526,15 +526,22 @@ def _apt_restart_services(restart: bool):
     """
     Context manager to conditionally restart services after apt operations.
 
-    :param restart: whether to restart services after apt operations
+    Args:
+        restart: whether to restart services after apt operations
     """
-    restore = os.environ.pop("NEEDRESTART_SUSPEND", None)
+    original = os.environ.get("NEEDRESTART_SUSPEND")
+    log("Services will {}be restarted after apt operations.".format("" if restart else "not "))
     if not restart:
-        log("Services will be not restarted after apt operations.")
         os.environ.update({"NEEDRESTART_SUSPEND": "1"})
-    yield
-    if restore is not None:
-        os.environ["NEEDRESTART_SUSPEND"] = restore
+    else:
+        os.environ.pop("NEEDRESTART_SUSPEND", None)
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("NEEDRESTART_SUSPEND", None)
+        else:
+            os.environ["NEEDRESTART_SUSPEND"] = original
 
 
 def reinstall_containerd(restart: bool = True):

--- a/tests/integration/test_containerd_integration.py
+++ b/tests/integration/test_containerd_integration.py
@@ -14,7 +14,6 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 from utils import JujuRun
 import yaml
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,4 @@
 import charms.unit_test
 
-
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module("requests")

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -407,3 +407,45 @@ def test_needs_gpu_reboot_true(check_output, is_state, remove_state, set_state):
     check_output.assert_called_once_with(["nvidia-smi"], stderr=STDOUT)
     set_state.assert_called_once_with("containerd.nvidia.needs_reboot")
     remove_state.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "restart,initial_env,expected_during,expected_after,log_called",
+    [
+        (True, {}, None, None, False),
+        (False, {}, "1", "1", True),
+        (True, {"NEEDRESTART_SUSPEND": "original_value"}, None, "original_value", False),
+        (False, {"NEEDRESTART_SUSPEND": "original_value"}, "1", "original_value", True),
+    ],
+    ids=[
+        "restart=True, no initial env",
+        "restart=False, no initial env",
+        "restart=True, with initial env",
+        "restart=False, with initial env",
+    ],
+)
+@mock.patch.object(containerd, "log")
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_apt_restart_services(mock_log, restart, initial_env, expected_during, expected_after, log_called):
+    """Verify _apt_restart_services behavior with various configurations."""
+    # Setup initial environment from parameters
+    os.environ.update(initial_env)
+
+    with containerd._apt_restart_services(restart=restart):
+        # Check value during context
+        if expected_during is None:
+            assert "NEEDRESTART_SUSPEND" not in os.environ
+        else:
+            assert os.environ["NEEDRESTART_SUSPEND"] == expected_during
+
+    # Check value after context
+    if expected_after is None:
+        assert "NEEDRESTART_SUSPEND" not in os.environ
+    else:
+        assert os.environ["NEEDRESTART_SUSPEND"] == expected_after
+
+    # Check log call
+    if log_called:
+        mock_log.assert_called_once_with("Services will be not restarted after apt operations.")
+    else:
+        mock_log.assert_not_called()

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -414,8 +414,8 @@ def test_needs_gpu_reboot_true(check_output, is_state, remove_state, set_state):
     [
         (True, {}, None, None),
         (False, {}, "1", None),
-        (True, {"NEEDRESTART_SUSPEND": "original"}, None, "original"),
-        (False, {"NEEDRESTART_SUSPEND": "original"}, "1", "original"),
+        (True, {containerd.NEEDRESTART_SUSPEND: "original"}, None, "original"),
+        (False, {containerd.NEEDRESTART_SUSPEND: "original"}, "1", "original"),
     ],
     ids=[
         "restart=True, no initial env",
@@ -430,19 +430,20 @@ def test_apt_restart_services(mock_log, restart, initial_env, expected_during, e
     """Verify _apt_restart_services behavior with various configurations."""
     # Setup initial environment from parameters
     os.environ.update(initial_env)
+    env_var = containerd.NEEDRESTART_SUSPEND
 
     with containerd._apt_restart_services(restart=restart):
         # Check value during context
         if expected_during is None:
-            assert "NEEDRESTART_SUSPEND" not in os.environ
+            assert env_var not in os.environ
         else:
-            assert os.environ["NEEDRESTART_SUSPEND"] == expected_during
+            assert os.environ[env_var] == expected_during
 
     # Check value after context
     if expected_after is None:
-        assert "NEEDRESTART_SUSPEND" not in os.environ
+        assert env_var not in os.environ
     else:
-        assert os.environ["NEEDRESTART_SUSPEND"] == expected_after
+        assert os.environ[env_var] == expected_after
 
     # Check log call
     log_fmt = "" if restart else "not "

--- a/tests/unit/test_containerd_reactive.py
+++ b/tests/unit/test_containerd_reactive.py
@@ -410,12 +410,12 @@ def test_needs_gpu_reboot_true(check_output, is_state, remove_state, set_state):
 
 
 @pytest.mark.parametrize(
-    "restart,initial_env,expected_during,expected_after,log_called",
+    "restart,initial_env,expected_during,expected_after",
     [
-        (True, {}, None, None, False),
-        (False, {}, "1", "1", True),
-        (True, {"NEEDRESTART_SUSPEND": "original_value"}, None, "original_value", False),
-        (False, {"NEEDRESTART_SUSPEND": "original_value"}, "1", "original_value", True),
+        (True, {}, None, None),
+        (False, {}, "1", None),
+        (True, {"NEEDRESTART_SUSPEND": "original"}, None, "original"),
+        (False, {"NEEDRESTART_SUSPEND": "original"}, "1", "original"),
     ],
     ids=[
         "restart=True, no initial env",
@@ -426,7 +426,7 @@ def test_needs_gpu_reboot_true(check_output, is_state, remove_state, set_state):
 )
 @mock.patch.object(containerd, "log")
 @mock.patch.dict(os.environ, {}, clear=True)
-def test_apt_restart_services(mock_log, restart, initial_env, expected_during, expected_after, log_called):
+def test_apt_restart_services(mock_log, restart, initial_env, expected_during, expected_after):
     """Verify _apt_restart_services behavior with various configurations."""
     # Setup initial environment from parameters
     os.environ.update(initial_env)
@@ -445,7 +445,5 @@ def test_apt_restart_services(mock_log, restart, initial_env, expected_during, e
         assert os.environ["NEEDRESTART_SUSPEND"] == expected_after
 
     # Check log call
-    if log_called:
-        mock_log.assert_called_once_with("Services will be not restarted after apt operations.")
-    else:
-        mock_log.assert_not_called()
+    log_fmt = "" if restart else "not "
+    mock_log.assert_called_once_with(f"Services will {log_fmt}be restarted after apt operations.")


### PR DESCRIPTION
Bug fix [LP#2143365](https://bugs.launchpad.net/charm-containerd/+bug/2143365)

#84 introduced a change where containerd is apt install even if the bin is replaced using a charm resource.  That's fine, but the charm shouldn't restart containerd when its resource managed. 

This change prevents service restarts of containerd when the binary is resource managed.