### PR TITLE
chore: mark optional endpoints as optional in metadata

### DIFF
--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -20,10 +20,12 @@ requires:
     scope: container
   docker-registry:
     interface: docker-registry
+    optional: true
 provides:
   untrusted:
     interface: untrusted-container-runtime
     scope: container
+    optional: true
 resources:
   containerd:
     type: file


### PR DESCRIPTION
Mark `docker-registry` (requires) and `untrusted` (provides) as `optional: true`. Both are gated on `@when` handlers that only activate when the relation is present; the charm starts and serves correctly without either.