### PR TITLE
Pin RELEASE_BRANCH to release_1.36 on release_1.36

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -36,4 +36,4 @@ parts:
     - CHARM_LAYERS_DIR: $CRAFT_STAGE/tmp/layers/
     - CHARM_INTERFACES_DIR: $CRAFT_STAGE/tmp/interfaces/
     - LAYER_INDEX: https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/
-    - RELEASE_BRANCH: main
+    - RELEASE_BRANCH: release_1.36

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,4 @@
 charms.reactive==1.5.3
+pbr==7.0.3
 setuptools==70.3.0
 setuptools-scm==7.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,26 +22,20 @@ deps =
     jinja2
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 commands =
-    pytest \
-       --cov-report term-missing \
-       --cov charms.layer.containerd --cov-fail-under 100 \
-       --cov reactive.containerd --cov-fail-under 45 \
-       --cov-report=html:{toxinidir}/report/unit/coverage-html \
-       -vv \
-       --tb native -s {posargs} {toxinidir}/tests/unit
+    pytest        --cov-report term-missing        --cov charms.layer.containerd --cov-fail-under 100        --cov reactive.containerd --cov-fail-under 45        --cov-report=html:{toxinidir}/report/unit/coverage-html        -vv        --tb native -s {posargs} {toxinidir}/tests/unit
 
 [testenv:lint]
 deps =
     flake8
     flake8-docstrings
-    black
+    black==25.11.0
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check --line-length=120 {toxinidir}/src {toxinidir}/tests
 
 [testenv:format]
 envdir = {toxworkdir}/lint
-deps = black
+deps = black==25.11.0
 commands =
     black --line-length=120 {toxinidir}/src {toxinidir}/tests
 
@@ -54,12 +48,7 @@ deps =
     toml
     tenacity
 commands =
-    pytest --tb native \
-           --show-capture=no \
-           --asyncio-mode=auto \
-           --log-cli-level=INFO \
-           -s {posargs} \
-           {toxinidir}/tests/integration
+    pytest --tb native            --show-capture=no            --asyncio-mode=auto            --log-cli-level=INFO            -s {posargs}            {toxinidir}/tests/integration
 
 [testenv:validate-wheelhouse]
 deps =


### PR DESCRIPTION
## Summary
- set `RELEASE_BRANCH` to `release_1.36` in `charmcraft.yaml`
- ensure reactive charm builds on `release_1.36` use the matching release branch for layer selection

## Testing
- verified `charmcraft.yaml` contains `RELEASE_BRANCH: release_1.36`
