### PR TITLE
chore(release_1.36): backport ghcr.io image registry migration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,8 +2,6 @@ name: Run tests with Tox
 
 on:
   pull_request:
-    branches:
-    - main
 
 jobs:
   call-inclusive-naming-check:

--- a/src/lib/charms/layer/containerd.py
+++ b/src/lib/charms/layer/containerd.py
@@ -90,7 +90,7 @@ def get_sandbox_image():
     :return: str container image location
     """
     db = unitdata.kv()
-    canonical_registry = "rocks.canonical.com:443/cdk"
+    canonical_registry = "ghcr.io/canonical/cdk"
     upstream_registry = "k8s.gcr.io"
 
     docker_registry = db.get("registry", None)

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,4 @@
 charms.reactive==1.5.3
+pbr==7.0.3
 setuptools==70.3.0
 setuptools-scm==7.1.0

--- a/tests/integration/test_containerd_integration.py
+++ b/tests/integration/test_containerd_integration.py
@@ -14,7 +14,6 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 from utils import JujuRun
 import yaml
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,4 @@
 import charms.unit_test
 
-
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module("requests")

--- a/tests/unit/test_containerd_lib.py
+++ b/tests/unit/test_containerd_lib.py
@@ -16,7 +16,7 @@ def test_get_sandbox_image():
     """Verify we return a sandbox image from the appropriate registry."""
     image_name = "pause:3.6"
 
-    canonical_registry = "rocks.canonical.com:443/cdk"
+    canonical_registry = "ghcr.io/canonical/cdk"
     related_registry = "my.registry.com:5000"
     upstream_registry = "k8s.gcr.io"
 


### PR DESCRIPTION
Cherry-picks the rocks.c.c → ghcr.io migration onto `release_1.36`.

**Source:** https://github.com/charmed-kubernetes/charm-containerd/pull/104 — _feat: update image-registry default to ghcr.io/canonical/cdk_
**Commit:** `229587308`

Cherry-picked cleanly with no conflicts.